### PR TITLE
refactor: use defaultProps as proxy for some props

### DIFF
--- a/.unit-test-results.json
+++ b/.unit-test-results.json
@@ -8,483 +8,9 @@
   "numFailedTests": 0,
   "numPendingTests": 0,
   "numTodoTests": 0,
-  "startTime": 1661427411124,
+  "startTime": 1661778021225,
   "success": true,
   "testResults": [
-    {
-      "assertionResults": [
-        {
-          "ancestorTitles": [
-            "",
-            "directive/focusFirst"
-          ],
-          "fullName": " directive/focusFirst do nothing when element does not have focusable element",
-          "status": "passed",
-          "title": "do nothing when element does not have focusable element",
-          "duration": 55,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "directive/focusFirst"
-          ],
-          "fullName": " directive/focusFirst focus first focusable child element",
-          "status": "passed",
-          "title": "focus first focusable child element",
-          "duration": 13,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "directive/focusFirst"
-          ],
-          "fullName": " directive/focusFirst focus first focusable and not disabled child element",
-          "status": "passed",
-          "title": "focus first focusable and not disabled child element",
-          "duration": 9,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "directive/focusFirst"
-          ],
-          "fullName": " directive/focusFirst focus first child with tabindex",
-          "status": "passed",
-          "title": "focus first child with tabindex",
-          "duration": 6,
-          "failureMessages": []
-        }
-      ],
-      "startTime": 1661427414070,
-      "endTime": 1661427414154,
-      "status": "passed",
-      "message": "",
-      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/utilities/directives/focus-first/focus-first.spec.js"
-    },
-    {
-      "assertionResults": [
-        {
-          "ancestorTitles": [
-            "",
-            "UiRadio.vue"
-          ],
-          "fullName": " UiRadio.vue renders a component",
-          "status": "passed",
-          "title": "renders a component",
-          "duration": 36,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiRadio.vue"
-          ],
-          "fullName": " UiRadio.vue render a content via default slot",
-          "status": "passed",
-          "title": "render a content via default slot",
-          "duration": 31,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiRadio.vue"
-          ],
-          "fullName": " UiRadio.vue render a content via radio slot",
-          "status": "passed",
-          "title": "render a content via radio slot",
-          "duration": 6,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiRadio.vue"
-          ],
-          "fullName": " UiRadio.vue render default id for non passed id property",
-          "status": "passed",
-          "title": "render default id for non passed id property",
-          "duration": 7,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiRadio.vue"
-          ],
-          "fullName": " UiRadio.vue a radio click emits change event",
-          "status": "passed",
-          "title": "a radio click emits change event",
-          "duration": 6,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiRadio.vue"
-          ],
-          "fullName": " UiRadio.vue a component pass Object as value",
-          "status": "passed",
-          "title": "a component pass Object as value",
-          "duration": 4,
-          "failureMessages": []
-        }
-      ],
-      "startTime": 1661427415626,
-      "endTime": 1661427415716,
-      "status": "passed",
-      "message": "",
-      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/atoms/UiRadio/UiRadio.spec.js"
-    },
-    {
-      "assertionResults": [
-        {
-          "ancestorTitles": [
-            "",
-            "UiModal.vue"
-          ],
-          "fullName": " UiModal.vue renders a component",
-          "status": "passed",
-          "title": "renders a component",
-          "duration": 84,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiModal.vue"
-          ],
-          "fullName": " UiModal.vue component can be open by model value",
-          "status": "passed",
-          "title": "component can be open by model value",
-          "duration": 22,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiModal.vue"
-          ],
-          "fullName": " UiModal.vue component can be closed by clicking outside when is closable",
-          "status": "passed",
-          "title": "component can be closed by clicking outside when is closable",
-          "duration": 39,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiModal.vue"
-          ],
-          "fullName": " UiModal.vue component can't be closed by clicking outside when is unclosable",
-          "status": "passed",
-          "title": "component can't be closed by clicking outside when is unclosable",
-          "duration": 24,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiModal.vue"
-          ],
-          "fullName": " UiModal.vue component emit confirm event",
-          "status": "passed",
-          "title": "component emit confirm event",
-          "duration": 12,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiModal.vue"
-          ],
-          "fullName": " UiModal.vue component emit cancel event",
-          "status": "passed",
-          "title": "component emit cancel event",
-          "duration": 11,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiModal.vue"
-          ],
-          "fullName": " UiModal.vue title scope slot renders content for title when component has title and description props",
-          "status": "passed",
-          "title": "title scope slot renders content for title when component has title and description props",
-          "duration": 116,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiModal.vue"
-          ],
-          "fullName": " UiModal.vue title slot is not rendered if component does not have title prop",
-          "status": "passed",
-          "title": "title slot is not rendered if component does not have title prop",
-          "duration": 26,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiModal.vue"
-          ],
-          "fullName": " UiModal.vue description scope slot render content for description when component has title and description props",
-          "status": "passed",
-          "title": "description scope slot render content for description when component has title and description props",
-          "duration": 84,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiModal.vue"
-          ],
-          "fullName": " UiModal.vue description scope slot render content for description if component does not have title prop",
-          "status": "passed",
-          "title": "description scope slot render content for description if component does not have title prop",
-          "duration": 28,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiModal.vue"
-          ],
-          "fullName": " UiModal.vue description scope slot is rendered once if component does not have title prop",
-          "status": "passed",
-          "title": "description scope slot is rendered once if component does not have title prop",
-          "duration": 41,
-          "failureMessages": []
-        }
-      ],
-      "startTime": 1661427416036,
-      "endTime": 1661427416523,
-      "status": "passed",
-      "message": "",
-      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/organisms/UiModal/UiModal.spec.js"
-    },
-    {
-      "assertionResults": [
-        {
-          "ancestorTitles": [
-            "",
-            "UiRange.vue"
-          ],
-          "fullName": " UiRange.vue renders a component",
-          "status": "passed",
-          "title": "renders a component",
-          "duration": 60,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiRange.vue"
-          ],
-          "fullName": " UiRange.vue renders a content via value slot",
-          "status": "passed",
-          "title": "renders a content via value slot",
-          "duration": 38,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiRange.vue"
-          ],
-          "fullName": " UiRange.vue renders a content via decrement slot",
-          "status": "passed",
-          "title": "renders a content via decrement slot",
-          "duration": 12,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiRange.vue"
-          ],
-          "fullName": " UiRange.vue renders a content via increment slot",
-          "status": "passed",
-          "title": "renders a content via increment slot",
-          "duration": 11,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiRange.vue"
-          ],
-          "fullName": " UiRange.vue percent position of thumb is right",
-          "status": "passed",
-          "title": "percent position of thumb is right",
-          "duration": 12,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiRange.vue"
-          ],
-          "fullName": " UiRange.vue pass percent position of thumb to component style",
-          "status": "passed",
-          "title": "pass percent position of thumb to component style",
-          "duration": 9,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiRange.vue"
-          ],
-          "fullName": " UiRange.vue clicking increment button increments the value",
-          "status": "passed",
-          "title": "clicking increment button increments the value",
-          "duration": 22,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiRange.vue"
-          ],
-          "fullName": " UiRange.vue clicking decrement button decrements the value",
-          "status": "passed",
-          "title": "clicking decrement button decrements the value",
-          "duration": 11,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiRange.vue"
-          ],
-          "fullName": " UiRange.vue component passes attributes to child button components",
-          "status": "passed",
-          "title": "component passes attributes to child button components",
-          "duration": 23,
-          "failureMessages": []
-        }
-      ],
-      "startTime": 1661427416036,
-      "endTime": 1661427416235,
-      "status": "passed",
-      "message": "",
-      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/atoms/UiRange/UiRange.spec.js"
-    },
-    {
-      "assertionResults": [
-        {
-          "ancestorTitles": [
-            "",
-            "UiScale.vue"
-          ],
-          "fullName": " UiScale.vue renders a component",
-          "status": "passed",
-          "title": "renders a component",
-          "duration": 100,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiScale.vue"
-          ],
-          "fullName": " UiScale.vue renders a content via decrement slot",
-          "status": "passed",
-          "title": "renders a content via decrement slot",
-          "duration": 61,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiScale.vue"
-          ],
-          "fullName": " UiScale.vue renders a content via increment slot",
-          "status": "passed",
-          "title": "renders a content via increment slot",
-          "duration": 120,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiScale.vue"
-          ],
-          "fullName": " UiScale.vue rendes certein number of options",
-          "status": "passed",
-          "title": "rendes certein number of options",
-          "duration": 117,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiScale.vue"
-          ],
-          "fullName": " UiScale.vue pain value pass to component",
-          "status": "passed",
-          "title": "pain value pass to component",
-          "duration": 70,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiScale.vue"
-          ],
-          "fullName": " UiScale.vue clicking increment button increments scale value",
-          "status": "passed",
-          "title": "clicking increment button increments scale value",
-          "duration": 67,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiScale.vue"
-          ],
-          "fullName": " UiScale.vue clicking decrement button decrements scale value",
-          "status": "passed",
-          "title": "clicking decrement button decrements scale value",
-          "duration": 72,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiScale.vue"
-          ],
-          "fullName": " UiScale.vue incrementing by button dont get value out of scale bounds",
-          "status": "passed",
-          "title": "incrementing by button dont get value out of scale bounds",
-          "duration": 55,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiScale.vue"
-          ],
-          "fullName": " UiScale.vue decrementing by button dont get value out of scale bounds",
-          "status": "passed",
-          "title": "decrementing by button dont get value out of scale bounds",
-          "duration": 85,
-          "failureMessages": []
-        }
-      ],
-      "startTime": 1661427416079,
-      "endTime": 1661427416826,
-      "status": "passed",
-      "message": "",
-      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/molecules/UiScale/UiScale.spec.js"
-    },
     {
       "assertionResults": [
         {
@@ -496,7 +22,7 @@
           "fullName": " UiStepper.vue shared renders a component",
           "status": "passed",
           "title": "renders a component",
-          "duration": 53,
+          "duration": 54,
           "failureMessages": []
         },
         {
@@ -508,7 +34,7 @@
           "fullName": " UiStepper.vue mobile renders a component in mobile version",
           "status": "passed",
           "title": "renders a component in mobile version",
-          "duration": 41,
+          "duration": 43,
           "failureMessages": []
         },
         {
@@ -520,7 +46,7 @@
           "fullName": " UiStepper.vue mobile renders a component displaying correct step number",
           "status": "passed",
           "title": "renders a component displaying correct step number",
-          "duration": 24,
+          "duration": 20,
           "failureMessages": []
         },
         {
@@ -532,7 +58,7 @@
           "fullName": " UiStepper.vue desktop renders a component in desktop version",
           "status": "passed",
           "title": "renders a component in desktop version",
-          "duration": 19,
+          "duration": 14,
           "failureMessages": []
         },
         {
@@ -544,7 +70,7 @@
           "fullName": " UiStepper.vue desktop renders a component with active class on the active element",
           "status": "passed",
           "title": "renders a component with active class on the active element",
-          "duration": 26,
+          "duration": 15,
           "failureMessages": []
         },
         {
@@ -556,12 +82,12 @@
           "fullName": " UiStepper.vue desktop renders a component with visited class on the visited elements",
           "status": "passed",
           "title": "renders a component with visited class on the visited elements",
-          "duration": 42,
+          "duration": 24,
           "failureMessages": []
         }
       ],
-      "startTime": 1661427416099,
-      "endTime": 1661427416305,
+      "startTime": 1661778026607,
+      "endTime": 1661778026778,
       "status": "passed",
       "message": "",
       "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/molecules/UiStepper/UiStepper.spec.js"
@@ -571,300 +97,421 @@
         {
           "ancestorTitles": [
             "",
-            "UiDatepicker.vue"
+            "UiRange.vue"
           ],
-          "fullName": " UiDatepicker.vue renders a component",
+          "fullName": " UiRange.vue renders a component",
           "status": "passed",
           "title": "renders a component",
-          "duration": 122,
+          "duration": 118,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "UiDatepicker.vue"
+            "UiRange.vue"
           ],
-          "fullName": " UiDatepicker.vue open calendar with day tab when all fields are filled",
+          "fullName": " UiRange.vue renders a content via value slot",
           "status": "passed",
-          "title": "open calendar with day tab when all fields are filled",
-          "duration": 631,
+          "title": "renders a content via value slot",
+          "duration": 55,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "UiDatepicker.vue"
+            "UiRange.vue"
           ],
-          "fullName": " UiDatepicker.vue open calendar with month tab when all fields are filled",
+          "fullName": " UiRange.vue renders a content via decrement slot",
           "status": "passed",
-          "title": "open calendar with month tab when all fields are filled",
-          "duration": 622,
+          "title": "renders a content via decrement slot",
+          "duration": 14,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "UiDatepicker.vue"
+            "UiRange.vue"
           ],
-          "fullName": " UiDatepicker.vue open calendar with year tab when all fields are filled",
+          "fullName": " UiRange.vue renders a content via increment slot",
           "status": "passed",
-          "title": "open calendar with year tab when all fields are filled",
-          "duration": 402,
+          "title": "renders a content via increment slot",
+          "duration": 34,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "UiDatepicker.vue"
+            "UiRange.vue"
           ],
-          "fullName": " UiDatepicker.vue open calendar with day tab when non fields are filled",
+          "fullName": " UiRange.vue percent position of thumb is right",
           "status": "passed",
-          "title": "open calendar with day tab when non fields are filled",
-          "duration": 461,
+          "title": "percent position of thumb is right",
+          "duration": 14,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "UiDatepicker.vue"
+            "UiRange.vue"
           ],
-          "fullName": " UiDatepicker.vue open calendar with month tab when non fields are filled",
+          "fullName": " UiRange.vue pass percent position of thumb to component style",
           "status": "passed",
-          "title": "open calendar with month tab when non fields are filled",
-          "duration": 382,
+          "title": "pass percent position of thumb to component style",
+          "duration": 10,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "UiDatepicker.vue"
+            "UiRange.vue"
           ],
-          "fullName": " UiDatepicker.vue open calendar with year tab when non fields are filled",
+          "fullName": " UiRange.vue clicking increment button increments the value",
           "status": "passed",
-          "title": "open calendar with year tab when non fields are filled",
-          "duration": 340,
+          "title": "clicking increment button increments the value",
+          "duration": 24,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "UiDatepicker.vue"
+            "UiRange.vue"
           ],
-          "fullName": " UiDatepicker.vue close calendar when all fields are filled",
+          "fullName": " UiRange.vue clicking decrement button decrements the value",
           "status": "passed",
-          "title": "close calendar when all fields are filled",
-          "duration": 761,
+          "title": "clicking decrement button decrements the value",
+          "duration": 24,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "UiDatepicker.vue"
+            "UiRange.vue"
           ],
-          "fullName": " UiDatepicker.vue calendar is still open after focus on any input",
+          "fullName": " UiRange.vue component passes attributes to child button components",
           "status": "passed",
-          "title": "calendar is still open after focus on any input",
-          "duration": 432,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiDatepicker.vue"
-          ],
-          "fullName": " UiDatepicker.vue focuses calendar button after select date on calendar",
-          "status": "passed",
-          "title": "focuses calendar button after select date on calendar",
-          "duration": 610,
+          "title": "component passes attributes to child button components",
+          "duration": 28,
           "failureMessages": []
         }
       ],
-      "startTime": 1661427417235,
-      "endTime": 1661427421998,
+      "startTime": 1661778026967,
+      "endTime": 1661778027288,
       "status": "passed",
       "message": "",
-      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/organisms/UiDatepicker/UiDatepicker.spec.js"
+      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/atoms/UiRange/UiRange.spec.js"
     },
     {
       "assertionResults": [
         {
           "ancestorTitles": [
             "",
-            "UiToggleButtonGroup.vue"
+            "UiModal.vue"
           ],
-          "fullName": " UiToggleButtonGroup.vue renders a component",
+          "fullName": " UiModal.vue renders a component",
           "status": "passed",
           "title": "renders a component",
-          "duration": 30,
+          "duration": 118,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "UiToggleButtonGroup.vue"
+            "UiModal.vue"
           ],
-          "fullName": " UiToggleButtonGroup.vue updates modelValue after click a first toggle button",
+          "fullName": " UiModal.vue component can be open by model value",
           "status": "passed",
-          "title": "updates modelValue after click a first toggle button",
-          "duration": 41,
+          "title": "component can be open by model value",
+          "duration": 24,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "UiToggleButtonGroup.vue"
+            "UiModal.vue"
           ],
-          "fullName": " UiToggleButtonGroup.vue unpressed a first item after third item clicked",
+          "fullName": " UiModal.vue component can be closed by clicking outside when is closable",
           "status": "passed",
-          "title": "unpressed a first item after third item clicked",
-          "duration": 17,
+          "title": "component can be closed by clicking outside when is closable",
+          "duration": 48,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "UiToggleButtonGroup.vue"
+            "UiModal.vue"
           ],
-          "fullName": " UiToggleButtonGroup.vue deselects item when deselectable props is set",
+          "fullName": " UiModal.vue component can't be closed by clicking outside when is unclosable",
           "status": "passed",
-          "title": "deselects item when deselectable props is set",
-          "duration": 21,
+          "title": "component can't be closed by clicking outside when is unclosable",
+          "duration": 26,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "UiToggleButtonGroup.vue"
+            "UiModal.vue"
           ],
-          "fullName": " UiToggleButtonGroup.vue not deselects item when deselectable props is not set",
+          "fullName": " UiModal.vue component emit confirm event",
           "status": "passed",
-          "title": "not deselects item when deselectable props is not set",
-          "duration": 15,
+          "title": "component emit confirm event",
+          "duration": 38,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "UiToggleButtonGroup.vue"
+            "UiModal.vue"
           ],
-          "fullName": " UiToggleButtonGroup.vue updates value with object values",
+          "fullName": " UiModal.vue component emit cancel event",
           "status": "passed",
-          "title": "updates value with object values",
-          "duration": 12,
+          "title": "component emit cancel event",
+          "duration": 13,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiModal.vue"
+          ],
+          "fullName": " UiModal.vue title scope slot renders content for title when component has title and description props",
+          "status": "passed",
+          "title": "title scope slot renders content for title when component has title and description props",
+          "duration": 64,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiModal.vue"
+          ],
+          "fullName": " UiModal.vue title slot is not rendered if component does not have title prop",
+          "status": "passed",
+          "title": "title slot is not rendered if component does not have title prop",
+          "duration": 36,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiModal.vue"
+          ],
+          "fullName": " UiModal.vue description scope slot render content for description when component has title and description props",
+          "status": "passed",
+          "title": "description scope slot render content for description when component has title and description props",
+          "duration": 149,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiModal.vue"
+          ],
+          "fullName": " UiModal.vue description scope slot render content for description if component does not have title prop",
+          "status": "passed",
+          "title": "description scope slot render content for description if component does not have title prop",
+          "duration": 31,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiModal.vue"
+          ],
+          "fullName": " UiModal.vue description scope slot is rendered once if component does not have title prop",
+          "status": "passed",
+          "title": "description scope slot is rendered once if component does not have title prop",
+          "duration": 47,
           "failureMessages": []
         }
       ],
-      "startTime": 1661427417399,
-      "endTime": 1661427417535,
+      "startTime": 1661778027025,
+      "endTime": 1661778027619,
       "status": "passed",
       "message": "",
-      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/molecules/UiToggleButtonGroup/UiToggleButtonGroup.spec.js"
+      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/organisms/UiModal/UiModal.spec.js"
     },
     {
       "assertionResults": [
         {
           "ancestorTitles": [
             "",
-            "UiAlert.vue"
+            "UiScale.vue"
           ],
-          "fullName": " UiAlert.vue renders a component",
+          "fullName": " UiScale.vue renders a component",
           "status": "passed",
           "title": "renders a component",
-          "duration": 75,
+          "duration": 114,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "UiAlert.vue"
+            "UiScale.vue"
           ],
-          "fullName": " UiAlert.vue renders content via icon slot",
+          "fullName": " UiScale.vue renders a content via decrement slot",
           "status": "passed",
-          "title": "renders content via icon slot",
-          "duration": 120,
+          "title": "renders a content via decrement slot",
+          "duration": 86,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "UiAlert.vue"
+            "UiScale.vue"
           ],
-          "fullName": " UiAlert.vue renders content via message slot",
+          "fullName": " UiScale.vue renders a content via increment slot",
           "status": "passed",
-          "title": "renders content via message slot",
-          "duration": 9,
-          "failureMessages": []
-        }
-      ],
-      "startTime": 1661427418279,
-      "endTime": 1661427418483,
-      "status": "passed",
-      "message": "",
-      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/molecules/UiAlert/UiAlert.spec.js"
-    },
-    {
-      "assertionResults": [
-        {
-          "ancestorTitles": [
-            "",
-            "UiHeading.vue"
-          ],
-          "fullName": " UiHeading.vue renders a component",
-          "status": "passed",
-          "title": "renders a component",
-          "duration": 46,
+          "title": "renders a content via increment slot",
+          "duration": 45,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "UiHeading.vue"
+            "UiScale.vue"
           ],
-          "fullName": " UiHeading.vue renders an h2 element by default",
+          "fullName": " UiScale.vue rendes certein number of options",
           "status": "passed",
-          "title": "renders an h2 element by default",
+          "title": "rendes certein number of options",
+          "duration": 197,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiScale.vue"
+          ],
+          "fullName": " UiScale.vue pain value pass to component",
+          "status": "passed",
+          "title": "pain value pass to component",
+          "duration": 47,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiScale.vue"
+          ],
+          "fullName": " UiScale.vue clicking increment button increments scale value",
+          "status": "passed",
+          "title": "clicking increment button increments scale value",
           "duration": 85,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "UiHeading.vue"
+            "UiScale.vue"
           ],
-          "fullName": " UiHeading.vue renders heading corresponding to selected level",
+          "fullName": " UiScale.vue clicking decrement button decrements scale value",
           "status": "passed",
-          "title": "renders heading corresponding to selected level",
-          "duration": 5,
+          "title": "clicking decrement button decrements scale value",
+          "duration": 98,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "UiHeading.vue"
+            "UiScale.vue"
           ],
-          "fullName": " UiHeading.vue renders heading tag provided by tag prop",
+          "fullName": " UiScale.vue incrementing by button dont get value out of scale bounds",
           "status": "passed",
-          "title": "renders heading tag provided by tag prop",
-          "duration": 5,
+          "title": "incrementing by button dont get value out of scale bounds",
+          "duration": 57,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "UiHeading.vue"
+            "UiScale.vue"
           ],
-          "fullName": " UiHeading.vue renders different styles for an element when special class is provided",
+          "fullName": " UiScale.vue decrementing by button dont get value out of scale bounds",
           "status": "passed",
-          "title": "renders different styles for an element when special class is provided",
-          "duration": 5,
+          "title": "decrementing by button dont get value out of scale bounds",
+          "duration": 99,
           "failureMessages": []
         }
       ],
-      "startTime": 1661427419085,
-      "endTime": 1661427419231,
+      "startTime": 1661778027096,
+      "endTime": 1661778027924,
       "status": "passed",
       "message": "",
-      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/atoms/UiHeading/UiHeading.spec.js"
+      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/molecules/UiScale/UiScale.spec.js"
+    },
+    {
+      "assertionResults": [
+        {
+          "ancestorTitles": [
+            "",
+            "UiDropdown.vue"
+          ],
+          "fullName": " UiDropdown.vue renders a component",
+          "status": "passed",
+          "title": "renders a component",
+          "duration": 67,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiDropdown.vue"
+          ],
+          "fullName": " UiDropdown.vue render a content from text props",
+          "status": "passed",
+          "title": "render a content from text props",
+          "duration": 23,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiDropdown.vue"
+          ],
+          "fullName": " UiDropdown.vue render a content via default slot",
+          "status": "passed",
+          "title": "render a content via default slot",
+          "duration": 35,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiDropdown.vue"
+          ],
+          "fullName": " UiDropdown.vue render a content via toggle slot",
+          "status": "passed",
+          "title": "render a content via toggle slot",
+          "duration": 6,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiDropdown.vue"
+          ],
+          "fullName": " UiDropdown.vue render a content via content slot",
+          "status": "passed",
+          "title": "render a content via content slot",
+          "duration": 12,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiDropdown.vue"
+          ],
+          "fullName": " UiDropdown.vue a trigger button click open dropdown",
+          "status": "passed",
+          "title": "a trigger button click open dropdown",
+          "duration": 16,
+          "failureMessages": []
+        }
+      ],
+      "startTime": 1661778027375,
+      "endTime": 1661778027534,
+      "status": "passed",
+      "message": "",
+      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/molecules/UiDropdown/UiDropdown.spec.js"
     },
     {
       "assertionResults": [
@@ -877,7 +524,7 @@
           "fullName": " UiMultipleAnswer.vue Component with Radioses renders a component with radio buttons when modelValue is a string",
           "status": "passed",
           "title": "renders a component with radio buttons when modelValue is a string",
-          "duration": 100,
+          "duration": 72,
           "failureMessages": []
         },
         {
@@ -889,7 +536,7 @@
           "fullName": " UiMultipleAnswer.vue Component with Radioses renders a component with radio buttons when modelValue is an object",
           "status": "passed",
           "title": "renders a component with radio buttons when modelValue is an object",
-          "duration": 58,
+          "duration": 24,
           "failureMessages": []
         },
         {
@@ -901,7 +548,7 @@
           "fullName": " UiMultipleAnswer.vue Component with Radioses renders a component with correct number of radioses",
           "status": "passed",
           "title": "renders a component with correct number of radioses",
-          "duration": 31,
+          "duration": 23,
           "failureMessages": []
         },
         {
@@ -913,7 +560,7 @@
           "fullName": " UiMultipleAnswer.vue Component with Radioses renders a component and radioses with error styles when invalid and touched prop is true",
           "status": "passed",
           "title": "renders a component and radioses with error styles when invalid and touched prop is true",
-          "duration": 47,
+          "duration": 49,
           "failureMessages": []
         },
         {
@@ -925,7 +572,7 @@
           "fullName": " UiMultipleAnswer.vue Component with Radioses renders a component and radioses with error styles when invalid prop is false and touched prop is true",
           "status": "passed",
           "title": "renders a component and radioses with error styles when invalid prop is false and touched prop is true",
-          "duration": 38,
+          "duration": 30,
           "failureMessages": []
         },
         {
@@ -937,7 +584,7 @@
           "fullName": " UiMultipleAnswer.vue Component with Checkboxes renders a component with checkboxes when modelValue is an array",
           "status": "passed",
           "title": "renders a component with checkboxes when modelValue is an array",
-          "duration": 61,
+          "duration": 34,
           "failureMessages": []
         },
         {
@@ -949,7 +596,7 @@
           "fullName": " UiMultipleAnswer.vue Component with Checkboxes renders a component correct number of checkboxes",
           "status": "passed",
           "title": "renders a component correct number of checkboxes",
-          "duration": 23,
+          "duration": 97,
           "failureMessages": []
         },
         {
@@ -961,7 +608,7 @@
           "fullName": " UiMultipleAnswer.vue Component with Checkboxes renders a component and checkboxes with error styles when invalid and touched prop is true",
           "status": "passed",
           "title": "renders a component and checkboxes with error styles when invalid and touched prop is true",
-          "duration": 92,
+          "duration": 18,
           "failureMessages": []
         },
         {
@@ -973,12 +620,12 @@
           "fullName": " UiMultipleAnswer.vue Component with Checkboxes renders a component and checkboxes with error styles when invalid prop is false and touched prop is true",
           "status": "passed",
           "title": "renders a component and checkboxes with error styles when invalid prop is false and touched prop is true",
-          "duration": 24,
+          "duration": 78,
           "failureMessages": []
         }
       ],
-      "startTime": 1661427419255,
-      "endTime": 1661427419730,
+      "startTime": 1661778027475,
+      "endTime": 1661778027900,
       "status": "passed",
       "message": "",
       "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/organisms/UiMultipleAnswer/UiMultipleAnswer.spec.js"
@@ -988,625 +635,119 @@
         {
           "ancestorTitles": [
             "",
-            "UiNumberStepper.vue"
+            "UiDatepicker.vue"
           ],
-          "fullName": " UiNumberStepper.vue renders a component",
+          "fullName": " UiDatepicker.vue renders a component",
           "status": "passed",
           "title": "renders a component",
-          "duration": 57,
+          "duration": 114,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "UiNumberStepper.vue"
+            "UiDatepicker.vue"
           ],
-          "fullName": " UiNumberStepper.vue clicking decrement button decrement the value",
+          "fullName": " UiDatepicker.vue open calendar with day tab when all fields are filled",
           "status": "passed",
-          "title": "clicking decrement button decrement the value",
-          "duration": 111,
+          "title": "open calendar with day tab when all fields are filled",
+          "duration": 602,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "UiNumberStepper.vue"
+            "UiDatepicker.vue"
           ],
-          "fullName": " UiNumberStepper.vue clicking increment button increment the value",
+          "fullName": " UiDatepicker.vue open calendar with month tab when all fields are filled",
           "status": "passed",
-          "title": "clicking increment button increment the value",
-          "duration": 11,
+          "title": "open calendar with month tab when all fields are filled",
+          "duration": 620,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "UiNumberStepper.vue"
+            "UiDatepicker.vue"
           ],
-          "fullName": " UiNumberStepper.vue value can't be smallest than min",
+          "fullName": " UiDatepicker.vue open calendar with year tab when all fields are filled",
           "status": "passed",
-          "title": "value can't be smallest than min",
-          "duration": 11,
+          "title": "open calendar with year tab when all fields are filled",
+          "duration": 459,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "UiNumberStepper.vue"
+            "UiDatepicker.vue"
           ],
-          "fullName": " UiNumberStepper.vue value can't be bigger than max",
+          "fullName": " UiDatepicker.vue open calendar with day tab when non fields are filled",
           "status": "passed",
-          "title": "value can't be bigger than max",
-          "duration": 15,
+          "title": "open calendar with day tab when non fields are filled",
+          "duration": 472,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiDatepicker.vue"
+          ],
+          "fullName": " UiDatepicker.vue open calendar with month tab when non fields are filled",
+          "status": "passed",
+          "title": "open calendar with month tab when non fields are filled",
+          "duration": 419,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiDatepicker.vue"
+          ],
+          "fullName": " UiDatepicker.vue open calendar with year tab when non fields are filled",
+          "status": "passed",
+          "title": "open calendar with year tab when non fields are filled",
+          "duration": 392,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiDatepicker.vue"
+          ],
+          "fullName": " UiDatepicker.vue close calendar when all fields are filled",
+          "status": "passed",
+          "title": "close calendar when all fields are filled",
+          "duration": 1024,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiDatepicker.vue"
+          ],
+          "fullName": " UiDatepicker.vue calendar is still open after focus on any input",
+          "status": "passed",
+          "title": "calendar is still open after focus on any input",
+          "duration": 412,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiDatepicker.vue"
+          ],
+          "fullName": " UiDatepicker.vue focuses calendar button after select date on calendar",
+          "status": "passed",
+          "title": "focuses calendar button after select date on calendar",
+          "duration": 715,
           "failureMessages": []
         }
       ],
-      "startTime": 1661427419557,
-      "endTime": 1661427419762,
+      "startTime": 1661778028358,
+      "endTime": 1661778033590,
       "status": "passed",
       "message": "",
-      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/molecules/UiNumberStepper/UiNumberStepper.spec.js"
-    },
-    {
-      "assertionResults": [
-        {
-          "ancestorTitles": [
-            "",
-            "UiMultipleChoices.vue"
-          ],
-          "fullName": " UiMultipleChoices.vue renders a component",
-          "status": "passed",
-          "title": "renders a component",
-          "duration": 41,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiMultipleChoices.vue"
-          ],
-          "fullName": " UiMultipleChoices.vue a component emits update:modelValue as array",
-          "status": "passed",
-          "title": "a component emits update:modelValue as array",
-          "duration": 110,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiMultipleChoices.vue"
-          ],
-          "fullName": " UiMultipleChoices.vue a possible to pass custom choices by options property",
-          "status": "passed",
-          "title": "a possible to pass custom choices by options property",
-          "duration": 33,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiMultipleChoices.vue"
-          ],
-          "fullName": " UiMultipleChoices.vue a possible to valid custom choices component",
-          "status": "passed",
-          "title": "a possible to valid custom choices component",
-          "duration": 49,
-          "failureMessages": []
-        }
-      ],
-      "startTime": 1661427419580,
-      "endTime": 1661427419813,
-      "status": "passed",
-      "message": "",
-      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/organisms/UiMultipleChoices/UiMultipleChoices.spec.js"
-    },
-    {
-      "assertionResults": [
-        {
-          "ancestorTitles": [
-            "",
-            "UiDropdown.vue"
-          ],
-          "fullName": " UiDropdown.vue renders a component",
-          "status": "passed",
-          "title": "renders a component",
-          "duration": 132,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiDropdown.vue"
-          ],
-          "fullName": " UiDropdown.vue render a content from text props",
-          "status": "passed",
-          "title": "render a content from text props",
-          "duration": 24,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiDropdown.vue"
-          ],
-          "fullName": " UiDropdown.vue render a content via default slot",
-          "status": "passed",
-          "title": "render a content via default slot",
-          "duration": 68,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiDropdown.vue"
-          ],
-          "fullName": " UiDropdown.vue render a content via toggle slot",
-          "status": "passed",
-          "title": "render a content via toggle slot",
-          "duration": 9,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiDropdown.vue"
-          ],
-          "fullName": " UiDropdown.vue render a content via content slot",
-          "status": "passed",
-          "title": "render a content via content slot",
-          "duration": 33,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiDropdown.vue"
-          ],
-          "fullName": " UiDropdown.vue a trigger button click open dropdown",
-          "status": "passed",
-          "title": "a trigger button click open dropdown",
-          "duration": 14,
-          "failureMessages": []
-        }
-      ],
-      "startTime": 1661427420462,
-      "endTime": 1661427420742,
-      "status": "passed",
-      "message": "",
-      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/molecules/UiDropdown/UiDropdown.spec.js"
-    },
-    {
-      "assertionResults": [
-        {
-          "ancestorTitles": [
-            "",
-            "directive/focusTrap"
-          ],
-          "fullName": " directive/focusTrap focus state goes from last child to first child when press Tab",
-          "status": "passed",
-          "title": "focus state goes from last child to first child when press Tab",
-          "duration": 158,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "directive/focusTrap"
-          ],
-          "fullName": " directive/focusTrap focus state goes from first child to last child when press Tab + Shift",
-          "status": "passed",
-          "title": "focus state goes from first child to last child when press Tab + Shift",
-          "duration": 17,
-          "failureMessages": []
-        }
-      ],
-      "startTime": 1661427421343,
-      "endTime": 1661427421518,
-      "status": "passed",
-      "message": "",
-      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/utilities/directives/focus-trap/focus-trap.spec.js"
-    },
-    {
-      "assertionResults": [
-        {
-          "ancestorTitles": [
-            "",
-            "UiSidePanel.vue"
-          ],
-          "fullName": " UiSidePanel.vue renders a component",
-          "status": "passed",
-          "title": "renders a component",
-          "duration": 36,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiSidePanel.vue"
-          ],
-          "fullName": " UiSidePanel.vue a component can be open by model value",
-          "status": "passed",
-          "title": "a component can be open by model value",
-          "duration": 44,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiSidePanel.vue"
-          ],
-          "fullName": " UiSidePanel.vue render a content via default slot",
-          "status": "passed",
-          "title": "render a content via default slot",
-          "duration": 35,
-          "failureMessages": []
-        }
-      ],
-      "startTime": 1661427422252,
-      "endTime": 1661427422368,
-      "status": "passed",
-      "message": "",
-      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/organisms/UiSidePanel/UiSidePanel.spec.js"
-    },
-    {
-      "assertionResults": [
-        {
-          "ancestorTitles": [
-            "",
-            "UiControls.vue"
-          ],
-          "fullName": " UiControls.vue renders a component",
-          "status": "passed",
-          "title": "renders a component",
-          "duration": 52,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiControls.vue"
-          ],
-          "fullName": " UiControls.vue component does not show next button when \"hideNextButton\" is true",
-          "status": "passed",
-          "title": "component does not show next button when \"hideNextButton\" is true",
-          "duration": 18,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiControls.vue"
-          ],
-          "fullName": " UiControls.vue component does not show next button when \"toNext\" is absent",
-          "status": "passed",
-          "title": "component does not show next button when \"toNext\" is absent",
-          "duration": 7,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiControls.vue"
-          ],
-          "fullName": " UiControls.vue component does not show back button when \"toBack\" is absent",
-          "status": "passed",
-          "title": "component does not show back button when \"toBack\" is absent",
-          "duration": 6,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiControls.vue"
-          ],
-          "fullName": " UiControls.vue component has disabled next button when \"invalid\" is true and \"toNext\" is present",
-          "status": "passed",
-          "title": "component has disabled next button when \"invalid\" is true and \"toNext\" is present",
-          "duration": 11,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiControls.vue"
-          ],
-          "fullName": " UiControls.vue component emit has-error when \"invalid\" is true and \"toNext\" is present",
-          "status": "passed",
-          "title": "component emit has-error when \"invalid\" is true and \"toNext\" is present",
-          "duration": 10,
-          "failureMessages": []
-        }
-      ],
-      "startTime": 1661427422799,
-      "endTime": 1661427422903,
-      "status": "passed",
-      "message": "",
-      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/organisms/UiControls/UiControls.spec.js"
-    },
-    {
-      "assertionResults": [
-        {
-          "ancestorTitles": [
-            "",
-            "UiPopover.vue"
-          ],
-          "fullName": " UiPopover.vue renders a component",
-          "status": "passed",
-          "title": "renders a component",
-          "duration": 36,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiPopover.vue"
-          ],
-          "fullName": " UiPopover.vue a component emit close event",
-          "status": "passed",
-          "title": "a component emit close event",
-          "duration": 39,
-          "failureMessages": []
-        }
-      ],
-      "startTime": 1661427422838,
-      "endTime": 1661427422913,
-      "status": "passed",
-      "message": "",
-      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/molecules/UiPopover/UiPopover.spec.js"
-    },
-    {
-      "assertionResults": [
-        {
-          "ancestorTitles": [
-            "",
-            "UiAccordion.vue"
-          ],
-          "fullName": " UiAccordion.vue renders a component",
-          "status": "passed",
-          "title": "renders a component",
-          "duration": 37,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiAccordion.vue"
-          ],
-          "fullName": " UiAccordion.vue component emit single item for String v-model",
-          "status": "passed",
-          "title": "component emit single item for String v-model",
-          "duration": 54,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiAccordion.vue"
-          ],
-          "fullName": " UiAccordion.vue component emit multiple items for Array v-model",
-          "status": "passed",
-          "title": "component emit multiple items for Array v-model",
-          "duration": 16,
-          "failureMessages": []
-        }
-      ],
-      "startTime": 1661427422844,
-      "endTime": 1661427422951,
-      "status": "passed",
-      "message": "",
-      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/organisms/UiAccordion/UiAccordion.spec.js"
-    },
-    {
-      "assertionResults": [
-        {
-          "ancestorTitles": [
-            "",
-            "UiTabs.vue"
-          ],
-          "fullName": " UiTabs.vue renders a component",
-          "status": "passed",
-          "title": "renders a component",
-          "duration": 45,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiTabs.vue"
-          ],
-          "fullName": " UiTabs.vue component emit single item for String v-model",
-          "status": "passed",
-          "title": "component emit single item for String v-model",
-          "duration": 94,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiTabs.vue"
-          ],
-          "fullName": " UiTabs.vue component emit update for UiTabsItem with id instead name",
-          "status": "passed",
-          "title": "component emit update for UiTabsItem with id instead name",
-          "duration": 17,
-          "failureMessages": []
-        }
-      ],
-      "startTime": 1661427423445,
-      "endTime": 1661427423602,
-      "status": "passed",
-      "message": "",
-      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/organisms/UiTabs/UiTabs.spec.js"
-    },
-    {
-      "assertionResults": [
-        {
-          "ancestorTitles": [
-            "",
-            "directive/bodyScrollLock"
-          ],
-          "fullName": " directive/bodyScrollLock The directive add styles to body",
-          "status": "passed",
-          "title": "The directive add styles to body",
-          "duration": 55,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "directive/bodyScrollLock"
-          ],
-          "fullName": " directive/bodyScrollLock The directive removes body styles before the component unmounts",
-          "status": "passed",
-          "title": "The directive removes body styles before the component unmounts",
-          "duration": 14,
-          "failureMessages": []
-        }
-      ],
-      "startTime": 1661427424076,
-      "endTime": 1661427424145,
-      "status": "passed",
-      "message": "",
-      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/utilities/directives/body-scroll-lock/body-scroll-lock.spec.js"
-    },
-    {
-      "assertionResults": [
-        {
-          "ancestorTitles": [
-            "",
-            "directive/scrollTabindex"
-          ],
-          "fullName": " directive/scrollTabindex remove tabindex if scrollHeight is lower than clientHeight",
-          "status": "passed",
-          "title": "remove tabindex if scrollHeight is lower than clientHeight",
-          "duration": 70,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "directive/scrollTabindex"
-          ],
-          "fullName": " directive/scrollTabindex adding tabindex if scrollHeight changed",
-          "status": "passed",
-          "title": "adding tabindex if scrollHeight changed",
-          "duration": 8,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "directive/scrollTabindex"
-          ],
-          "fullName": " directive/scrollTabindex remove tabindex if clientHeight changed",
-          "status": "passed",
-          "title": "remove tabindex if clientHeight changed",
-          "duration": 7,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "directive/scrollTabindex"
-          ],
-          "fullName": " directive/scrollTabindex remove tabindex if scrollHeight equals clientHeight",
-          "status": "passed",
-          "title": "remove tabindex if scrollHeight equals clientHeight",
-          "duration": 4,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "directive/scrollTabindex"
-          ],
-          "fullName": " directive/scrollTabindex add tabindex if scrollHeight is greater than clientHeight",
-          "status": "passed",
-          "title": "add tabindex if scrollHeight is greater than clientHeight",
-          "duration": 8,
-          "failureMessages": []
-        }
-      ],
-      "startTime": 1661427424608,
-      "endTime": 1661427424705,
-      "status": "passed",
-      "message": "",
-      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/utilities/directives/scroll-tabindex/scroll-tabindex.spec.js"
-    },
-    {
-      "assertionResults": [
-        {
-          "ancestorTitles": [
-            "",
-            "UiInput.vue"
-          ],
-          "fullName": " UiInput.vue render a component",
-          "status": "passed",
-          "title": "render a component",
-          "duration": 110,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiInput.vue"
-          ],
-          "fullName": " UiInput.vue render a component with suffix",
-          "status": "passed",
-          "title": "render a component with suffix",
-          "duration": 36,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiInput.vue"
-          ],
-          "fullName": " UiInput.vue render a native attributes on input element",
-          "status": "passed",
-          "title": "render a native attributes on input element",
-          "duration": 20,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiInput.vue"
-          ],
-          "fullName": " UiInput.vue render a content via aside slot",
-          "status": "passed",
-          "title": "render a content via aside slot",
-          "duration": 19,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiInput.vue"
-          ],
-          "fullName": " UiInput.vue a component emits input event",
-          "status": "passed",
-          "title": "a component emits input event",
-          "duration": 23,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiInput.vue"
-          ],
-          "fullName": " UiInput.vue a number input cant accept non-numerical value",
-          "status": "passed",
-          "title": "a number input cant accept non-numerical value",
-          "duration": 11,
-          "failureMessages": []
-        }
-      ],
-      "startTime": 1661427424803,
-      "endTime": 1661427425022,
-      "status": "passed",
-      "message": "",
-      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/atoms/UiInput/UiInput.spec.js"
+      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/organisms/UiDatepicker/UiDatepicker.spec.js"
     },
     {
       "assertionResults": [
@@ -1618,7 +759,7 @@
           "fullName": " UiInteractiveSvg.vue renders a component",
           "status": "passed",
           "title": "renders a component",
-          "duration": 58,
+          "duration": 61,
           "failureMessages": []
         },
         {
@@ -1629,7 +770,7 @@
           "fullName": " UiInteractiveSvg.vue renders UiInteractiveSvgElement tag provided by tag prop",
           "status": "passed",
           "title": "renders UiInteractiveSvgElement tag provided by tag prop",
-          "duration": 15,
+          "duration": 54,
           "failureMessages": []
         },
         {
@@ -1640,7 +781,7 @@
           "fullName": " UiInteractiveSvg.vue pass attributes to UiInteractiveSvgElement",
           "status": "passed",
           "title": "pass attributes to UiInteractiveSvgElement",
-          "duration": 7,
+          "duration": 15,
           "failureMessages": []
         },
         {
@@ -1651,7 +792,7 @@
           "fullName": " UiInteractiveSvg.vue pass listeners to UiInteractiveSvgElement",
           "status": "passed",
           "title": "pass listeners to UiInteractiveSvgElement",
-          "duration": 13,
+          "duration": 11,
           "failureMessages": []
         },
         {
@@ -1673,7 +814,7 @@
           "fullName": " UiInteractiveSvg.vue do not pass nested attrs to higher levels of UiInteractiveSvg elements",
           "status": "passed",
           "title": "do not pass nested attrs to higher levels of UiInteractiveSvg elements",
-          "duration": 9,
+          "duration": 30,
           "failureMessages": []
         },
         {
@@ -1684,7 +825,7 @@
           "fullName": " UiInteractiveSvg.vue do not pass attrs to deeper levels of UiInteractiveSvg elements",
           "status": "passed",
           "title": "do not pass attrs to deeper levels of UiInteractiveSvg elements",
-          "duration": 6,
+          "duration": 12,
           "failureMessages": []
         },
         {
@@ -1695,7 +836,7 @@
           "fullName": " UiInteractiveSvg.vue pass listeners to nested UiInteractiveSvg elements",
           "status": "passed",
           "title": "pass listeners to nested UiInteractiveSvg elements",
-          "duration": 6,
+          "duration": 8,
           "failureMessages": []
         },
         {
@@ -1706,7 +847,7 @@
           "fullName": " UiInteractiveSvg.vue do not pass listeners to deeper levels of UiInteractiveSvg elements",
           "status": "passed",
           "title": "do not pass listeners to deeper levels of UiInteractiveSvg elements",
-          "duration": 8,
+          "duration": 9,
           "failureMessages": []
         },
         {
@@ -1717,12 +858,12 @@
           "fullName": " UiInteractiveSvg.vue do not pass nested listeners to higher levels of UiInteractiveSvg elements",
           "status": "passed",
           "title": "do not pass nested listeners to higher levels of UiInteractiveSvg elements",
-          "duration": 36,
+          "duration": 5,
           "failureMessages": []
         }
       ],
-      "startTime": 1661427425454,
-      "endTime": 1661427425672,
+      "startTime": 1661778029678,
+      "endTime": 1661778029943,
       "status": "passed",
       "message": "",
       "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/molecules/UiInteractiveSvg/UiInteractiveSvg.spec.js"
@@ -1732,298 +873,300 @@
         {
           "ancestorTitles": [
             "",
-            "UiButton.vue"
+            "UiMultipleChoices.vue"
           ],
-          "fullName": " UiButton.vue render a component",
+          "fullName": " UiMultipleChoices.vue renders a component",
           "status": "passed",
-          "title": "render a component",
-          "duration": 95,
+          "title": "renders a component",
+          "duration": 44,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "UiButton.vue"
+            "UiMultipleChoices.vue"
           ],
-          "fullName": " UiButton.vue render a content via default slot",
+          "fullName": " UiMultipleChoices.vue a component emits update:modelValue as array",
           "status": "passed",
-          "title": "render a content via default slot",
-          "duration": 21,
+          "title": "a component emits update:modelValue as array",
+          "duration": 120,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "UiButton.vue"
+            "UiMultipleChoices.vue"
           ],
-          "fullName": " UiButton.vue component is router-link when you pass it a \"to\" prop",
+          "fullName": " UiMultipleChoices.vue a possible to pass custom choices by options property",
           "status": "passed",
-          "title": "component is router-link when you pass it a \"to\" prop",
-          "duration": 5,
+          "title": "a possible to pass custom choices by options property",
+          "duration": 65,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "UiButton.vue"
+            "UiMultipleChoices.vue"
           ],
-          "fullName": " UiButton.vue component is link when you pass it a  \"href\" prop",
+          "fullName": " UiMultipleChoices.vue a possible to valid custom choices component",
           "status": "passed",
-          "title": "component is link when you pass it a  \"href\" prop",
+          "title": "a possible to valid custom choices component",
+          "duration": 31,
+          "failureMessages": []
+        }
+      ],
+      "startTime": 1661778030443,
+      "endTime": 1661778030703,
+      "status": "passed",
+      "message": "",
+      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/organisms/UiMultipleChoices/UiMultipleChoices.spec.js"
+    },
+    {
+      "assertionResults": [
+        {
+          "ancestorTitles": [
+            "",
+            "UiFormField.vue"
+          ],
+          "fullName": " UiFormField.vue renders a component",
+          "status": "passed",
+          "title": "renders a component",
+          "duration": 66,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiFormField.vue"
+          ],
+          "fullName": " UiFormField.vue renders component with custom label from slot",
+          "status": "passed",
+          "title": "renders component with custom label from slot",
+          "duration": 69,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiFormField.vue"
+          ],
+          "fullName": " UiFormField.vue renders component with custom label from slot and has only one label",
+          "status": "passed",
+          "title": "renders component with custom label from slot and has only one label",
+          "duration": 36,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiFormField.vue"
+          ],
+          "fullName": " UiFormField.vue renders a label when passed a label prop",
+          "status": "passed",
+          "title": "renders a label when passed a label prop",
           "duration": 12,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "UiButton.vue"
+            "UiFormField.vue"
           ],
-          "fullName": " UiButton.vue component is a button without \"to\" and \"href\" props",
+          "fullName": " UiFormField.vue renders an alert when passed an errorMessage prop",
           "status": "passed",
-          "title": "component is a button without \"to\" and \"href\" props",
-          "duration": 6,
-          "failureMessages": []
-        }
-      ],
-      "startTime": 1661427425501,
-      "endTime": 1661427425640,
-      "status": "passed",
-      "message": "",
-      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/atoms/UiButton/UiButton.spec.js"
-    },
-    {
-      "assertionResults": [
-        {
-          "ancestorTitles": [
-            "",
-            "directive/keyboardFocus"
-          ],
-          "fullName": " directive/keyboardFocus remove class focus-hidden from body when press tab",
-          "status": "passed",
-          "title": "remove class focus-hidden from body when press tab",
-          "duration": 97,
+          "title": "renders an alert when passed an errorMessage prop",
+          "duration": 10,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "directive/keyboardFocus"
+            "UiFormField.vue"
           ],
-          "fullName": " directive/keyboardFocus does not remove class focus-hidden from body when press other key than tab",
+          "fullName": " UiFormField.vue renders a hint alert when passed a label and hint props",
           "status": "passed",
-          "title": "does not remove class focus-hidden from body when press other key than tab",
-          "duration": 26,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "directive/keyboardFocus"
-          ],
-          "fullName": " directive/keyboardFocus focus element when press tab",
-          "status": "passed",
-          "title": "focus element when press tab",
-          "duration": 15,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "directive/keyboardFocus"
-          ],
-          "fullName": " directive/keyboardFocus add class focus-hidden to body on mouse click",
-          "status": "passed",
-          "title": "add class focus-hidden to body on mouse click",
-          "duration": 32,
-          "failureMessages": []
-        }
-      ],
-      "startTime": 1661427425569,
-      "endTime": 1661427425739,
-      "status": "passed",
-      "message": "",
-      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/utilities/directives/keyboard-focus/keyboard-focus.spec.js"
-    },
-    {
-      "assertionResults": [
-        {
-          "ancestorTitles": [
-            "",
-            "UiTextarea.vue"
-          ],
-          "fullName": " UiTextarea.vue renders a component",
-          "status": "passed",
-          "title": "renders a component",
-          "duration": 41,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiTextarea.vue"
-          ],
-          "fullName": " UiTextarea.vue render a native attributes on input element",
-          "status": "passed",
-          "title": "render a native attributes on input element",
-          "duration": 20,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiTextarea.vue"
-          ],
-          "fullName": " UiTextarea.vue a component emits input event",
-          "status": "passed",
-          "title": "a component emits input event",
-          "duration": 7,
-          "failureMessages": []
-        }
-      ],
-      "startTime": 1661427426309,
-      "endTime": 1661427426377,
-      "status": "passed",
-      "message": "",
-      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/atoms/UiTextarea/UiTextarea.spec.js"
-    },
-    {
-      "assertionResults": [
-        {
-          "ancestorTitles": [
-            "",
-            "UiSwitch.vue"
-          ],
-          "fullName": " UiSwitch.vue renders a component",
-          "status": "passed",
-          "title": "renders a component",
-          "duration": 56,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiSwitch.vue"
-          ],
-          "fullName": " UiSwitch.vue render a content via switchcontrol slot",
-          "status": "passed",
-          "title": "render a content via switchcontrol slot",
-          "duration": 96,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiSwitch.vue"
-          ],
-          "fullName": " UiSwitch.vue render a content via default slot",
-          "status": "passed",
-          "title": "render a content via default slot",
-          "duration": 18,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiSwitch.vue"
-          ],
-          "fullName": " UiSwitch.vue a component emits update event",
-          "status": "passed",
-          "title": "a component emits update event",
+          "title": "renders a hint alert when passed a label and hint props",
           "duration": 13,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "UiSwitch.vue"
+            "UiFormField.vue"
           ],
-          "fullName": " UiSwitch.vue a component is disabled",
+          "fullName": " UiFormField.vue does not render a hint alert when passed hint prop without label",
           "status": "passed",
-          "title": "a component is disabled",
-          "duration": 8,
+          "title": "does not render a hint alert when passed hint prop without label",
+          "duration": 7,
           "failureMessages": []
         }
       ],
-      "startTime": 1661427426952,
-      "endTime": 1661427427143,
+      "startTime": 1661778030510,
+      "endTime": 1661778030723,
       "status": "passed",
       "message": "",
-      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/molecules/UiSwitch/UiSwitch.spec.js"
+      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/molecules/UiFormField/UiFormField.spec.js"
     },
     {
       "assertionResults": [
         {
           "ancestorTitles": [
             "",
-            "directive/highlight"
+            "UiToggleButtonGroup.vue"
           ],
-          "fullName": " directive/highlight no markings if searched query is empty string",
+          "fullName": " UiToggleButtonGroup.vue renders a component",
           "status": "passed",
-          "title": "no markings if searched query is empty string",
-          "duration": 108,
+          "title": "renders a component",
+          "duration": 38,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "directive/highlight"
+            "UiToggleButtonGroup.vue"
           ],
-          "fullName": " directive/highlight marking searched query",
+          "fullName": " UiToggleButtonGroup.vue updates modelValue after click a first toggle button",
           "status": "passed",
-          "title": "marking searched query",
-          "duration": 18,
+          "title": "updates modelValue after click a first toggle button",
+          "duration": 54,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "directive/highlight"
+            "UiToggleButtonGroup.vue"
           ],
-          "fullName": " directive/highlight correct update markings searched query",
+          "fullName": " UiToggleButtonGroup.vue unpressed a first item after third item clicked",
           "status": "passed",
-          "title": "correct update markings searched query",
-          "duration": 141,
+          "title": "unpressed a first item after third item clicked",
+          "duration": 51,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "directive/highlight"
+            "UiToggleButtonGroup.vue"
           ],
-          "fullName": " directive/highlight no markings if text does not contain searched query",
+          "fullName": " UiToggleButtonGroup.vue deselects item when deselectable props is set",
           "status": "passed",
-          "title": "no markings if text does not contain searched query",
+          "title": "deselects item when deselectable props is set",
+          "duration": 31,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiToggleButtonGroup.vue"
+          ],
+          "fullName": " UiToggleButtonGroup.vue not deselects item when deselectable props is not set",
+          "status": "passed",
+          "title": "not deselects item when deselectable props is not set",
+          "duration": 10,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiToggleButtonGroup.vue"
+          ],
+          "fullName": " UiToggleButtonGroup.vue updates value with object values",
+          "status": "passed",
+          "title": "updates value with object values",
+          "duration": 12,
+          "failureMessages": []
+        }
+      ],
+      "startTime": 1661778030647,
+      "endTime": 1661778030844,
+      "status": "passed",
+      "message": "",
+      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/molecules/UiToggleButtonGroup/UiToggleButtonGroup.spec.js"
+    },
+    {
+      "assertionResults": [
+        {
+          "ancestorTitles": [
+            "",
+            "UiCheckbox.vue"
+          ],
+          "fullName": " UiCheckbox.vue render a component",
+          "status": "passed",
+          "title": "render a component",
+          "duration": 58,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiCheckbox.vue"
+          ],
+          "fullName": " UiCheckbox.vue render a content via default slot",
+          "status": "passed",
+          "title": "render a content via default slot",
+          "duration": 56,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiCheckbox.vue"
+          ],
+          "fullName": " UiCheckbox.vue render a content via checkbox slot",
+          "status": "passed",
+          "title": "render a content via checkbox slot",
           "duration": 12,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "directive/highlight"
+            "UiCheckbox.vue"
           ],
-          "fullName": " directive/highlight thrown error when search query is null",
+          "fullName": " UiCheckbox.vue render default id for non passed id property",
           "status": "passed",
-          "title": "thrown error when search query is null",
-          "duration": 20,
+          "title": "render default id for non passed id property",
+          "duration": 42,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "directive/highlight"
+            "UiCheckbox.vue"
           ],
-          "fullName": " directive/highlight thrown error when search query is undefined",
+          "fullName": " UiCheckbox.vue a checkbox click emits change event",
           "status": "passed",
-          "title": "thrown error when search query is undefined",
-          "duration": 7,
+          "title": "a checkbox click emits change event",
+          "duration": 10,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiCheckbox.vue"
+          ],
+          "fullName": " UiCheckbox.vue a component pass Object as value",
+          "status": "passed",
+          "title": "a component pass Object as value",
+          "duration": 16,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiCheckbox.vue"
+          ],
+          "fullName": " UiCheckbox.vue a component emits array for multiple checkboxes with object",
+          "status": "passed",
+          "title": "a component emits array for multiple checkboxes with object",
+          "duration": 12,
           "failureMessages": []
         }
       ],
-      "startTime": 1661427427375,
-      "endTime": 1661427427681,
+      "startTime": 1661778030897,
+      "endTime": 1661778031104,
       "status": "passed",
       "message": "",
-      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/utilities/directives/highlight/highlight.spec.js"
+      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/atoms/UiCheckbox/UiCheckbox.spec.js"
     },
     {
       "assertionResults": [
@@ -2035,7 +1178,7 @@
           "fullName": " UiRating.vue check if component renders",
           "status": "passed",
           "title": "check if component renders",
-          "duration": 69,
+          "duration": 57,
           "failureMessages": []
         },
         {
@@ -2057,12 +1200,12 @@
           "fullName": " UiRating.vue check if rate value pass to component",
           "status": "passed",
           "title": "check if rate value pass to component",
-          "duration": 68,
+          "duration": 48,
           "failureMessages": []
         }
       ],
-      "startTime": 1661427427830,
-      "endTime": 1661427428028,
+      "startTime": 1661778030939,
+      "endTime": 1661778031105,
       "status": "passed",
       "message": "",
       "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/molecules/UiRating/UiRating.spec.js"
@@ -2072,75 +1215,384 @@
         {
           "ancestorTitles": [
             "",
-            "directive/clickOutside"
+            "UiSidePanel.vue"
           ],
-          "fullName": " directive/clickOutside handler function is called when click outside",
+          "fullName": " UiSidePanel.vue renders a component",
           "status": "passed",
-          "title": "handler function is called when click outside",
-          "duration": 139,
+          "title": "renders a component",
+          "duration": 68,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "directive/clickOutside"
+            "UiSidePanel.vue"
           ],
-          "fullName": " directive/clickOutside handler function is not called when click root element",
+          "fullName": " UiSidePanel.vue a component can be open by model value",
           "status": "passed",
-          "title": "handler function is not called when click root element",
-          "duration": 23,
+          "title": "a component can be open by model value",
+          "duration": 112,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "directive/clickOutside"
+            "UiSidePanel.vue"
           ],
-          "fullName": " directive/clickOutside handler function is not called when click inside",
+          "fullName": " UiSidePanel.vue render a content via default slot",
           "status": "passed",
-          "title": "handler function is not called when click inside",
+          "title": "render a content via default slot",
+          "duration": 86,
+          "failureMessages": []
+        }
+      ],
+      "startTime": 1661778033175,
+      "endTime": 1661778033441,
+      "status": "passed",
+      "message": "",
+      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/organisms/UiSidePanel/UiSidePanel.spec.js"
+    },
+    {
+      "assertionResults": [
+        {
+          "ancestorTitles": [
+            "",
+            "UiRadio.vue"
+          ],
+          "fullName": " UiRadio.vue renders a component",
+          "status": "passed",
+          "title": "renders a component",
+          "duration": 115,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiRadio.vue"
+          ],
+          "fullName": " UiRadio.vue render a content via default slot",
+          "status": "passed",
+          "title": "render a content via default slot",
+          "duration": 86,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiRadio.vue"
+          ],
+          "fullName": " UiRadio.vue render a content via radio slot",
+          "status": "passed",
+          "title": "render a content via radio slot",
+          "duration": 38,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiRadio.vue"
+          ],
+          "fullName": " UiRadio.vue render default id for non passed id property",
+          "status": "passed",
+          "title": "render default id for non passed id property",
+          "duration": 10,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiRadio.vue"
+          ],
+          "fullName": " UiRadio.vue a radio click emits change event",
+          "status": "passed",
+          "title": "a radio click emits change event",
+          "duration": 10,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiRadio.vue"
+          ],
+          "fullName": " UiRadio.vue a component pass Object as value",
+          "status": "passed",
+          "title": "a component pass Object as value",
+          "duration": 6,
+          "failureMessages": []
+        }
+      ],
+      "startTime": 1661778033823,
+      "endTime": 1661778034088,
+      "status": "passed",
+      "message": "",
+      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/atoms/UiRadio/UiRadio.spec.js"
+    },
+    {
+      "assertionResults": [
+        {
+          "ancestorTitles": [
+            "",
+            "UiInput.vue"
+          ],
+          "fullName": " UiInput.vue render a component",
+          "status": "passed",
+          "title": "render a component",
+          "duration": 71,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiInput.vue"
+          ],
+          "fullName": " UiInput.vue render a component with suffix",
+          "status": "passed",
+          "title": "render a component with suffix",
+          "duration": 83,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiInput.vue"
+          ],
+          "fullName": " UiInput.vue render a native attributes on input element",
+          "status": "passed",
+          "title": "render a native attributes on input element",
+          "duration": 7,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiInput.vue"
+          ],
+          "fullName": " UiInput.vue render a content via aside slot",
+          "status": "passed",
+          "title": "render a content via aside slot",
+          "duration": 49,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiInput.vue"
+          ],
+          "fullName": " UiInput.vue a component emits input event",
+          "status": "passed",
+          "title": "a component emits input event",
           "duration": 14,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "directive/clickOutside"
+            "UiInput.vue"
           ],
-          "fullName": " directive/clickOutside adding false argument disables the directive",
+          "fullName": " UiInput.vue a number input cant accept non-numerical value",
           "status": "passed",
-          "title": "adding false argument disables the directive",
-          "duration": 28,
+          "title": "a number input cant accept non-numerical value",
+          "duration": 10,
+          "failureMessages": []
+        }
+      ],
+      "startTime": 1661778033916,
+      "endTime": 1661778034150,
+      "status": "passed",
+      "message": "",
+      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/atoms/UiInput/UiInput.spec.js"
+    },
+    {
+      "assertionResults": [
+        {
+          "ancestorTitles": [
+            "",
+            "UiControls.vue"
+          ],
+          "fullName": " UiControls.vue renders a component",
+          "status": "passed",
+          "title": "renders a component",
+          "duration": 89,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "directive/clickOutside"
+            "UiControls.vue"
           ],
-          "fullName": " directive/clickOutside handler function is called when argument is undefined",
+          "fullName": " UiControls.vue component does not show next button when \"hideNextButton\" is true",
           "status": "passed",
-          "title": "handler function is called when argument is undefined",
-          "duration": 26,
+          "title": "component does not show next button when \"hideNextButton\" is true",
+          "duration": 20,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "directive/clickOutside"
+            "UiControls.vue"
           ],
-          "fullName": " directive/clickOutside reactivity of argument",
+          "fullName": " UiControls.vue component does not show next button when \"toNext\" is absent",
           "status": "passed",
-          "title": "reactivity of argument",
+          "title": "component does not show next button when \"toNext\" is absent",
+          "duration": 52,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiControls.vue"
+          ],
+          "fullName": " UiControls.vue component does not show back button when \"toBack\" is absent",
+          "status": "passed",
+          "title": "component does not show back button when \"toBack\" is absent",
+          "duration": 40,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiControls.vue"
+          ],
+          "fullName": " UiControls.vue component has disabled next button when \"invalid\" is true and \"toNext\" is present",
+          "status": "passed",
+          "title": "component has disabled next button when \"invalid\" is true and \"toNext\" is present",
+          "duration": 12,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiControls.vue"
+          ],
+          "fullName": " UiControls.vue component emit has-error when \"invalid\" is true and \"toNext\" is present",
+          "status": "passed",
+          "title": "component emit has-error when \"invalid\" is true and \"toNext\" is present",
           "duration": 12,
           "failureMessages": []
         }
       ],
-      "startTime": 1661427428322,
-      "endTime": 1661427428564,
+      "startTime": 1661778034098,
+      "endTime": 1661778034324,
       "status": "passed",
       "message": "",
-      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/utilities/directives/click-outside/click-outside.spec.js"
+      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/organisms/UiControls/UiControls.spec.js"
+    },
+    {
+      "assertionResults": [
+        {
+          "ancestorTitles": [
+            "",
+            "UiSwitch.vue"
+          ],
+          "fullName": " UiSwitch.vue renders a component",
+          "status": "passed",
+          "title": "renders a component",
+          "duration": 82,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiSwitch.vue"
+          ],
+          "fullName": " UiSwitch.vue render a content via switchcontrol slot",
+          "status": "passed",
+          "title": "render a content via switchcontrol slot",
+          "duration": 58,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiSwitch.vue"
+          ],
+          "fullName": " UiSwitch.vue render a content via default slot",
+          "status": "passed",
+          "title": "render a content via default slot",
+          "duration": 45,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiSwitch.vue"
+          ],
+          "fullName": " UiSwitch.vue a component emits update event",
+          "status": "passed",
+          "title": "a component emits update event",
+          "duration": 15,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiSwitch.vue"
+          ],
+          "fullName": " UiSwitch.vue a component is disabled",
+          "status": "passed",
+          "title": "a component is disabled",
+          "duration": 12,
+          "failureMessages": []
+        }
+      ],
+      "startTime": 1661778034359,
+      "endTime": 1661778034571,
+      "status": "passed",
+      "message": "",
+      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/molecules/UiSwitch/UiSwitch.spec.js"
+    },
+    {
+      "assertionResults": [
+        {
+          "ancestorTitles": [
+            "",
+            "UiChip.vue"
+          ],
+          "fullName": " UiChip.vue renders a component",
+          "status": "passed",
+          "title": "renders a component",
+          "duration": 66,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiChip.vue"
+          ],
+          "fullName": " UiChip.vue component emit click:remove event",
+          "status": "passed",
+          "title": "component emit click:remove event",
+          "duration": 85,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiChip.vue"
+          ],
+          "fullName": " UiChip.vue a component pass attributes for remove button",
+          "status": "passed",
+          "title": "a component pass attributes for remove button",
+          "duration": 11,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiChip.vue"
+          ],
+          "fullName": " UiChip.vue render a content via remove slot",
+          "status": "passed",
+          "title": "render a content via remove slot",
+          "duration": 23,
+          "failureMessages": []
+        }
+      ],
+      "startTime": 1661778034388,
+      "endTime": 1661778034573,
+      "status": "passed",
+      "message": "",
+      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/molecules/UiChip/UiChip.spec.js"
     },
     {
       "assertionResults": [
@@ -2152,7 +1604,7 @@
           "fullName": " UiBulletPoints.vue renders a component",
           "status": "passed",
           "title": "renders a component",
-          "duration": 69,
+          "duration": 38,
           "failureMessages": []
         },
         {
@@ -2163,7 +1615,7 @@
           "fullName": " UiBulletPoints.vue component pass tag props",
           "status": "passed",
           "title": "component pass tag props",
-          "duration": 22,
+          "duration": 24,
           "failureMessages": []
         },
         {
@@ -2174,15 +1626,397 @@
           "fullName": " UiBulletPoints.vue component pass type props",
           "status": "passed",
           "title": "component pass type props",
-          "duration": 50,
+          "duration": 106,
           "failureMessages": []
         }
       ],
-      "startTime": 1661427428517,
-      "endTime": 1661427428659,
+      "startTime": 1661778036658,
+      "endTime": 1661778036826,
       "status": "passed",
       "message": "",
       "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/molecules/UiBulletPoints/UiBulletPoints.spec.js"
+    },
+    {
+      "assertionResults": [
+        {
+          "ancestorTitles": [
+            "",
+            "UiNumberStepper.vue"
+          ],
+          "fullName": " UiNumberStepper.vue renders a component",
+          "status": "passed",
+          "title": "renders a component",
+          "duration": 95,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiNumberStepper.vue"
+          ],
+          "fullName": " UiNumberStepper.vue clicking decrement button decrement the value",
+          "status": "passed",
+          "title": "clicking decrement button decrement the value",
+          "duration": 18,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiNumberStepper.vue"
+          ],
+          "fullName": " UiNumberStepper.vue clicking increment button increment the value",
+          "status": "passed",
+          "title": "clicking increment button increment the value",
+          "duration": 56,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiNumberStepper.vue"
+          ],
+          "fullName": " UiNumberStepper.vue value can't be smallest than min",
+          "status": "passed",
+          "title": "value can't be smallest than min",
+          "duration": 22,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiNumberStepper.vue"
+          ],
+          "fullName": " UiNumberStepper.vue value can't be bigger than max",
+          "status": "passed",
+          "title": "value can't be bigger than max",
+          "duration": 32,
+          "failureMessages": []
+        }
+      ],
+      "startTime": 1661778036845,
+      "endTime": 1661778037068,
+      "status": "passed",
+      "message": "",
+      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/molecules/UiNumberStepper/UiNumberStepper.spec.js"
+    },
+    {
+      "assertionResults": [
+        {
+          "ancestorTitles": [
+            "",
+            "UiAccordion.vue"
+          ],
+          "fullName": " UiAccordion.vue renders a component",
+          "status": "passed",
+          "title": "renders a component",
+          "duration": 39,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiAccordion.vue"
+          ],
+          "fullName": " UiAccordion.vue component emit single item for String v-model",
+          "status": "passed",
+          "title": "component emit single item for String v-model",
+          "duration": 43,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiAccordion.vue"
+          ],
+          "fullName": " UiAccordion.vue component emit multiple items for Array v-model",
+          "status": "passed",
+          "title": "component emit multiple items for Array v-model",
+          "duration": 16,
+          "failureMessages": []
+        }
+      ],
+      "startTime": 1661778037475,
+      "endTime": 1661778037573,
+      "status": "passed",
+      "message": "",
+      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/organisms/UiAccordion/UiAccordion.spec.js"
+    },
+    {
+      "assertionResults": [
+        {
+          "ancestorTitles": [
+            "",
+            "UiNotification.vue"
+          ],
+          "fullName": " UiNotification.vue renders a component",
+          "status": "passed",
+          "title": "renders a component",
+          "duration": 49,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiNotification.vue"
+          ],
+          "fullName": " UiNotification.vue component is success type",
+          "status": "passed",
+          "title": "component is success type",
+          "duration": 26,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiNotification.vue"
+          ],
+          "fullName": " UiNotification.vue component is info type",
+          "status": "passed",
+          "title": "component is info type",
+          "duration": 10,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiNotification.vue"
+          ],
+          "fullName": " UiNotification.vue component is warning type",
+          "status": "passed",
+          "title": "component is warning type",
+          "duration": 9,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiNotification.vue"
+          ],
+          "fullName": " UiNotification.vue component is error type",
+          "status": "passed",
+          "title": "component is error type",
+          "duration": 8,
+          "failureMessages": []
+        }
+      ],
+      "startTime": 1661778037499,
+      "endTime": 1661778037601,
+      "status": "passed",
+      "message": "",
+      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/molecules/UiNotification/UiNotification.spec.js"
+    },
+    {
+      "assertionResults": [
+        {
+          "ancestorTitles": [
+            "",
+            "UiTabs.vue"
+          ],
+          "fullName": " UiTabs.vue renders a component",
+          "status": "passed",
+          "title": "renders a component",
+          "duration": 36,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiTabs.vue"
+          ],
+          "fullName": " UiTabs.vue component emit single item for String v-model",
+          "status": "passed",
+          "title": "component emit single item for String v-model",
+          "duration": 169,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiTabs.vue"
+          ],
+          "fullName": " UiTabs.vue component emit update for UiTabsItem with id instead name",
+          "status": "passed",
+          "title": "component emit update for UiTabsItem with id instead name",
+          "duration": 32,
+          "failureMessages": []
+        }
+      ],
+      "startTime": 1661778037529,
+      "endTime": 1661778037766,
+      "status": "passed",
+      "message": "",
+      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/organisms/UiTabs/UiTabs.spec.js"
+    },
+    {
+      "assertionResults": [
+        {
+          "ancestorTitles": [
+            "",
+            "UiTile.vue"
+          ],
+          "fullName": " UiTile.vue renders a component",
+          "status": "passed",
+          "title": "renders a component",
+          "duration": 56,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiTile.vue"
+          ],
+          "fullName": " UiTile.vue renders a content via default slot",
+          "status": "passed",
+          "title": "renders a content via default slot",
+          "duration": 115,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiTile.vue"
+          ],
+          "fullName": " UiTile.vue a possible to pass icon by iconAttrs property",
+          "status": "passed",
+          "title": "a possible to pass icon by iconAttrs property",
+          "duration": 82,
+          "failureMessages": []
+        }
+      ],
+      "startTime": 1661778037546,
+      "endTime": 1661778037799,
+      "status": "passed",
+      "message": "",
+      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/molecules/UiTile/UiTile.spec.js"
+    },
+    {
+      "assertionResults": [
+        {
+          "ancestorTitles": [
+            "",
+            "directive/clickOutside"
+          ],
+          "fullName": " directive/clickOutside handler function is called when click outside",
+          "status": "passed",
+          "title": "handler function is called when click outside",
+          "duration": 206,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "directive/clickOutside"
+          ],
+          "fullName": " directive/clickOutside handler function is not called when click root element",
+          "status": "passed",
+          "title": "handler function is not called when click root element",
+          "duration": 8,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "directive/clickOutside"
+          ],
+          "fullName": " directive/clickOutside handler function is not called when click inside",
+          "status": "passed",
+          "title": "handler function is not called when click inside",
+          "duration": 11,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "directive/clickOutside"
+          ],
+          "fullName": " directive/clickOutside adding false argument disables the directive",
+          "status": "passed",
+          "title": "adding false argument disables the directive",
+          "duration": 7,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "directive/clickOutside"
+          ],
+          "fullName": " directive/clickOutside handler function is called when argument is undefined",
+          "status": "passed",
+          "title": "handler function is called when argument is undefined",
+          "duration": 8,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "directive/clickOutside"
+          ],
+          "fullName": " directive/clickOutside reactivity of argument",
+          "status": "passed",
+          "title": "reactivity of argument",
+          "duration": 16,
+          "failureMessages": []
+        }
+      ],
+      "startTime": 1661778037610,
+      "endTime": 1661778037866,
+      "status": "passed",
+      "message": "",
+      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/utilities/directives/click-outside/click-outside.spec.js"
+    },
+    {
+      "assertionResults": [
+        {
+          "ancestorTitles": [
+            "",
+            "directive/focusFirst"
+          ],
+          "fullName": " directive/focusFirst do nothing when element does not have focusable element",
+          "status": "passed",
+          "title": "do nothing when element does not have focusable element",
+          "duration": 134,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "directive/focusFirst"
+          ],
+          "fullName": " directive/focusFirst focus first focusable child element",
+          "status": "passed",
+          "title": "focus first focusable child element",
+          "duration": 100,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "directive/focusFirst"
+          ],
+          "fullName": " directive/focusFirst focus first focusable and not disabled child element",
+          "status": "passed",
+          "title": "focus first focusable and not disabled child element",
+          "duration": 11,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "directive/focusFirst"
+          ],
+          "fullName": " directive/focusFirst focus first child with tabindex",
+          "status": "passed",
+          "title": "focus first child with tabindex",
+          "duration": 17,
+          "failureMessages": []
+        }
+      ],
+      "startTime": 1661778039840,
+      "endTime": 1661778040102,
+      "status": "passed",
+      "message": "",
+      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/utilities/directives/focus-first/focus-first.spec.js"
     },
     {
       "assertionResults": [
@@ -2194,7 +2028,7 @@
           "fullName": " UiHeader.vue renders a component",
           "status": "passed",
           "title": "renders a component",
-          "duration": 56,
+          "duration": 53,
           "failureMessages": []
         },
         {
@@ -2216,7 +2050,7 @@
           "fullName": " UiHeader.vue hamburger should be visible on the mobile",
           "status": "passed",
           "title": "hamburger should be visible on the mobile",
-          "duration": 13,
+          "duration": 15,
           "failureMessages": []
         },
         {
@@ -2227,7 +2061,7 @@
           "fullName": " UiHeader.vue a component emits hamburger:open event",
           "status": "passed",
           "title": "a component emits hamburger:open event",
-          "duration": 14,
+          "duration": 15,
           "failureMessages": []
         },
         {
@@ -2238,12 +2072,12 @@
           "fullName": " UiHeader.vue a component emits hamburger:close event",
           "status": "passed",
           "title": "a component emits hamburger:close event",
-          "duration": 10,
+          "duration": 11,
           "failureMessages": []
         }
       ],
-      "startTime": 1661427428889,
-      "endTime": 1661427429005,
+      "startTime": 1661778040372,
+      "endTime": 1661778040489,
       "status": "passed",
       "message": "",
       "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/molecules/UiHeader/UiHeader.spec.js"
@@ -2253,384 +2087,148 @@
         {
           "ancestorTitles": [
             "",
-            "UiCheckbox.vue"
+            "directive/focusTrap"
           ],
-          "fullName": " UiCheckbox.vue render a component",
+          "fullName": " directive/focusTrap focus state goes from last child to first child when press Tab",
           "status": "passed",
-          "title": "render a component",
-          "duration": 117,
+          "title": "focus state goes from last child to first child when press Tab",
+          "duration": 134,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "UiCheckbox.vue"
+            "directive/focusTrap"
           ],
-          "fullName": " UiCheckbox.vue render a content via default slot",
+          "fullName": " directive/focusTrap focus state goes from first child to last child when press Tab + Shift",
           "status": "passed",
-          "title": "render a content via default slot",
-          "duration": 47,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiCheckbox.vue"
-          ],
-          "fullName": " UiCheckbox.vue render a content via checkbox slot",
-          "status": "passed",
-          "title": "render a content via checkbox slot",
-          "duration": 10,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiCheckbox.vue"
-          ],
-          "fullName": " UiCheckbox.vue render default id for non passed id property",
-          "status": "passed",
-          "title": "render default id for non passed id property",
-          "duration": 15,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiCheckbox.vue"
-          ],
-          "fullName": " UiCheckbox.vue a checkbox click emits change event",
-          "status": "passed",
-          "title": "a checkbox click emits change event",
-          "duration": 15,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiCheckbox.vue"
-          ],
-          "fullName": " UiCheckbox.vue a component pass Object as value",
-          "status": "passed",
-          "title": "a component pass Object as value",
-          "duration": 12,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiCheckbox.vue"
-          ],
-          "fullName": " UiCheckbox.vue a component emits array for multiple checkboxes with object",
-          "status": "passed",
-          "title": "a component emits array for multiple checkboxes with object",
-          "duration": 12,
+          "title": "focus state goes from first child to last child when press Tab + Shift",
+          "duration": 14,
           "failureMessages": []
         }
       ],
-      "startTime": 1661427429207,
-      "endTime": 1661427429436,
+      "startTime": 1661778040572,
+      "endTime": 1661778040720,
       "status": "passed",
       "message": "",
-      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/atoms/UiCheckbox/UiCheckbox.spec.js"
+      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/utilities/directives/focus-trap/focus-trap.spec.js"
     },
     {
       "assertionResults": [
         {
           "ancestorTitles": [
             "",
-            "UiNotification.vue"
+            "UiAlert.vue"
           ],
-          "fullName": " UiNotification.vue renders a component",
+          "fullName": " UiAlert.vue renders a component",
           "status": "passed",
           "title": "renders a component",
-          "duration": 71,
+          "duration": 104,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "UiNotification.vue"
+            "UiAlert.vue"
           ],
-          "fullName": " UiNotification.vue component is success type",
+          "fullName": " UiAlert.vue renders content via icon slot",
           "status": "passed",
-          "title": "component is success type",
-          "duration": 42,
+          "title": "renders content via icon slot",
+          "duration": 101,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "UiNotification.vue"
+            "UiAlert.vue"
           ],
-          "fullName": " UiNotification.vue component is info type",
+          "fullName": " UiAlert.vue renders content via message slot",
           "status": "passed",
-          "title": "component is info type",
-          "duration": 18,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiNotification.vue"
-          ],
-          "fullName": " UiNotification.vue component is warning type",
-          "status": "passed",
-          "title": "component is warning type",
-          "duration": 59,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiNotification.vue"
-          ],
-          "fullName": " UiNotification.vue component is error type",
-          "status": "passed",
-          "title": "component is error type",
-          "duration": 6,
+          "title": "renders content via message slot",
+          "duration": 23,
           "failureMessages": []
         }
       ],
-      "startTime": 1661427430041,
-      "endTime": 1661427430237,
+      "startTime": 1661778040597,
+      "endTime": 1661778040825,
       "status": "passed",
       "message": "",
-      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/molecules/UiNotification/UiNotification.spec.js"
+      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/molecules/UiAlert/UiAlert.spec.js"
     },
     {
       "assertionResults": [
         {
           "ancestorTitles": [
             "",
-            "UiChip.vue"
+            "directive/highlight"
           ],
-          "fullName": " UiChip.vue renders a component",
+          "fullName": " directive/highlight no markings if searched query is empty string",
           "status": "passed",
-          "title": "renders a component",
-          "duration": 75,
+          "title": "no markings if searched query is empty string",
+          "duration": 131,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "UiChip.vue"
+            "directive/highlight"
           ],
-          "fullName": " UiChip.vue component emit click:remove event",
+          "fullName": " directive/highlight marking searched query",
           "status": "passed",
-          "title": "component emit click:remove event",
-          "duration": 87,
+          "title": "marking searched query",
+          "duration": 107,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "UiChip.vue"
+            "directive/highlight"
           ],
-          "fullName": " UiChip.vue a component pass attributes for remove button",
+          "fullName": " directive/highlight correct update markings searched query",
           "status": "passed",
-          "title": "a component pass attributes for remove button",
-          "duration": 10,
+          "title": "correct update markings searched query",
+          "duration": 21,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "UiChip.vue"
+            "directive/highlight"
           ],
-          "fullName": " UiChip.vue render a content via remove slot",
+          "fullName": " directive/highlight no markings if text does not contain searched query",
           "status": "passed",
-          "title": "render a content via remove slot",
-          "duration": 18,
-          "failureMessages": []
-        }
-      ],
-      "startTime": 1661427430586,
-      "endTime": 1661427430776,
-      "status": "passed",
-      "message": "",
-      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/molecules/UiChip/UiChip.spec.js"
-    },
-    {
-      "assertionResults": [
-        {
-          "ancestorTitles": [
-            "",
-            "UiTile.vue"
-          ],
-          "fullName": " UiTile.vue renders a component",
-          "status": "passed",
-          "title": "renders a component",
-          "duration": 68,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiTile.vue"
-          ],
-          "fullName": " UiTile.vue renders a content via default slot",
-          "status": "passed",
-          "title": "renders a content via default slot",
+          "title": "no markings if text does not contain searched query",
           "duration": 40,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "UiTile.vue"
+            "directive/highlight"
           ],
-          "fullName": " UiTile.vue a possible to pass icon by iconAttrs property",
+          "fullName": " directive/highlight thrown error when search query is null",
           "status": "passed",
-          "title": "a possible to pass icon by iconAttrs property",
-          "duration": 71,
-          "failureMessages": []
-        }
-      ],
-      "startTime": 1661427431042,
-      "endTime": 1661427431221,
-      "status": "passed",
-      "message": "",
-      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/molecules/UiTile/UiTile.spec.js"
-    },
-    {
-      "assertionResults": [
-        {
-          "ancestorTitles": [
-            "",
-            "UiFormField.vue"
-          ],
-          "fullName": " UiFormField.vue renders a component",
-          "status": "passed",
-          "title": "renders a component",
-          "duration": 82,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiFormField.vue"
-          ],
-          "fullName": " UiFormField.vue renders component with custom label from slot",
-          "status": "passed",
-          "title": "renders component with custom label from slot",
-          "duration": 64,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiFormField.vue"
-          ],
-          "fullName": " UiFormField.vue renders component with custom label from slot and has only one label",
-          "status": "passed",
-          "title": "renders component with custom label from slot and has only one label",
+          "title": "thrown error when search query is null",
           "duration": 20,
           "failureMessages": []
         },
         {
           "ancestorTitles": [
             "",
-            "UiFormField.vue"
+            "directive/highlight"
           ],
-          "fullName": " UiFormField.vue renders a label when passed a label prop",
+          "fullName": " directive/highlight thrown error when search query is undefined",
           "status": "passed",
-          "title": "renders a label when passed a label prop",
-          "duration": 19,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiFormField.vue"
-          ],
-          "fullName": " UiFormField.vue renders an alert when passed an errorMessage prop",
-          "status": "passed",
-          "title": "renders an alert when passed an errorMessage prop",
-          "duration": 13,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiFormField.vue"
-          ],
-          "fullName": " UiFormField.vue renders a hint alert when passed a label and hint props",
-          "status": "passed",
-          "title": "renders a hint alert when passed a label and hint props",
-          "duration": 89,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiFormField.vue"
-          ],
-          "fullName": " UiFormField.vue does not render a hint alert when passed hint prop without label",
-          "status": "passed",
-          "title": "does not render a hint alert when passed hint prop without label",
+          "title": "thrown error when search query is undefined",
           "duration": 9,
           "failureMessages": []
         }
       ],
-      "startTime": 1661427431446,
-      "endTime": 1661427431742,
+      "startTime": 1661778040716,
+      "endTime": 1661778041044,
       "status": "passed",
       "message": "",
-      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/molecules/UiFormField/UiFormField.spec.js"
-    },
-    {
-      "assertionResults": [
-        {
-          "ancestorTitles": [
-            "",
-            "UiNavigation.vue"
-          ],
-          "fullName": " UiNavigation.vue renders a component",
-          "status": "passed",
-          "title": "renders a component",
-          "duration": 53,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiNavigation.vue"
-          ],
-          "fullName": " UiNavigation.vue component render item with the correct text",
-          "status": "passed",
-          "title": "component render item with the correct text",
-          "duration": 49,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiNavigation.vue"
-          ],
-          "fullName": " UiNavigation.vue component render the correct number of items",
-          "status": "passed",
-          "title": "component render the correct number of items",
-          "duration": 27,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiNavigation.vue"
-          ],
-          "fullName": " UiNavigation.vue component pass attributes to the one item",
-          "status": "passed",
-          "title": "component pass attributes to the one item",
-          "duration": 28,
-          "failureMessages": []
-        }
-      ],
-      "startTime": 1661427431507,
-      "endTime": 1661427431665,
-      "status": "passed",
-      "message": "",
-      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/molecules/UiNavigation/UiNavigation.spec.js"
+      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/utilities/directives/highlight/highlight.spec.js"
     },
     {
       "assertionResults": [
@@ -2642,7 +2240,7 @@
           "fullName": " UiSimpleQuestion.vue renders a component",
           "status": "passed",
           "title": "renders a component",
-          "duration": 93,
+          "duration": 76,
           "failureMessages": []
         },
         {
@@ -2653,15 +2251,501 @@
           "fullName": " UiSimpleQuestion.vue renders a component with correct amount of options",
           "status": "passed",
           "title": "renders a component with correct amount of options",
-          "duration": 36,
+          "duration": 33,
           "failureMessages": []
         }
       ],
-      "startTime": 1661427431899,
-      "endTime": 1661427432028,
+      "startTime": 1661778040782,
+      "endTime": 1661778040891,
       "status": "passed",
       "message": "",
       "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/organisms/UiSimpleQuestion/UiSimpleQuestion.spec.js"
+    },
+    {
+      "assertionResults": [
+        {
+          "ancestorTitles": [
+            "",
+            "UiNavigation.vue"
+          ],
+          "fullName": " UiNavigation.vue renders a component",
+          "status": "passed",
+          "title": "renders a component",
+          "duration": 88,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiNavigation.vue"
+          ],
+          "fullName": " UiNavigation.vue component render item with the correct text",
+          "status": "passed",
+          "title": "component render item with the correct text",
+          "duration": 50,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiNavigation.vue"
+          ],
+          "fullName": " UiNavigation.vue component render the correct number of items",
+          "status": "passed",
+          "title": "component render the correct number of items",
+          "duration": 30,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiNavigation.vue"
+          ],
+          "fullName": " UiNavigation.vue component pass attributes to the one item",
+          "status": "passed",
+          "title": "component pass attributes to the one item",
+          "duration": 31,
+          "failureMessages": []
+        }
+      ],
+      "startTime": 1661778040880,
+      "endTime": 1661778041079,
+      "status": "passed",
+      "message": "",
+      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/molecules/UiNavigation/UiNavigation.spec.js"
+    },
+    {
+      "assertionResults": [
+        {
+          "ancestorTitles": [
+            "",
+            "directive/keyboardFocus"
+          ],
+          "fullName": " directive/keyboardFocus remove class focus-hidden from body when press tab",
+          "status": "passed",
+          "title": "remove class focus-hidden from body when press tab",
+          "duration": 132,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "directive/keyboardFocus"
+          ],
+          "fullName": " directive/keyboardFocus does not remove class focus-hidden from body when press other key than tab",
+          "status": "passed",
+          "title": "does not remove class focus-hidden from body when press other key than tab",
+          "duration": 21,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "directive/keyboardFocus"
+          ],
+          "fullName": " directive/keyboardFocus focus element when press tab",
+          "status": "passed",
+          "title": "focus element when press tab",
+          "duration": 15,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "directive/keyboardFocus"
+          ],
+          "fullName": " directive/keyboardFocus add class focus-hidden to body on mouse click",
+          "status": "passed",
+          "title": "add class focus-hidden to body on mouse click",
+          "duration": 15,
+          "failureMessages": []
+        }
+      ],
+      "startTime": 1661778043084,
+      "endTime": 1661778043267,
+      "status": "passed",
+      "message": "",
+      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/utilities/directives/keyboard-focus/keyboard-focus.spec.js"
+    },
+    {
+      "assertionResults": [
+        {
+          "ancestorTitles": [
+            "",
+            "UiButton.vue"
+          ],
+          "fullName": " UiButton.vue render a component",
+          "status": "passed",
+          "title": "render a component",
+          "duration": 82,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiButton.vue"
+          ],
+          "fullName": " UiButton.vue render a content via default slot",
+          "status": "passed",
+          "title": "render a content via default slot",
+          "duration": 42,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiButton.vue"
+          ],
+          "fullName": " UiButton.vue component is router-link when you pass it a \"to\" prop",
+          "status": "passed",
+          "title": "component is router-link when you pass it a \"to\" prop",
+          "duration": 6,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiButton.vue"
+          ],
+          "fullName": " UiButton.vue component is link when you pass it a  \"href\" prop",
+          "status": "passed",
+          "title": "component is link when you pass it a  \"href\" prop",
+          "duration": 6,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiButton.vue"
+          ],
+          "fullName": " UiButton.vue component is a button without \"to\" and \"href\" props",
+          "status": "passed",
+          "title": "component is a button without \"to\" and \"href\" props",
+          "duration": 5,
+          "failureMessages": []
+        }
+      ],
+      "startTime": 1661778043447,
+      "endTime": 1661778043588,
+      "status": "passed",
+      "message": "",
+      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/atoms/UiButton/UiButton.spec.js"
+    },
+    {
+      "assertionResults": [
+        {
+          "ancestorTitles": [
+            "",
+            "UiPopover.vue"
+          ],
+          "fullName": " UiPopover.vue renders a component",
+          "status": "passed",
+          "title": "renders a component",
+          "duration": 86,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiPopover.vue"
+          ],
+          "fullName": " UiPopover.vue a component emit close event",
+          "status": "passed",
+          "title": "a component emit close event",
+          "duration": 121,
+          "failureMessages": []
+        }
+      ],
+      "startTime": 1661778043616,
+      "endTime": 1661778043823,
+      "status": "passed",
+      "message": "",
+      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/molecules/UiPopover/UiPopover.spec.js"
+    },
+    {
+      "assertionResults": [
+        {
+          "ancestorTitles": [
+            "",
+            "UiHeading.vue"
+          ],
+          "fullName": " UiHeading.vue renders a component",
+          "status": "passed",
+          "title": "renders a component",
+          "duration": 99,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiHeading.vue"
+          ],
+          "fullName": " UiHeading.vue renders an h2 element by default",
+          "status": "passed",
+          "title": "renders an h2 element by default",
+          "duration": 26,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiHeading.vue"
+          ],
+          "fullName": " UiHeading.vue renders heading corresponding to selected level",
+          "status": "passed",
+          "title": "renders heading corresponding to selected level",
+          "duration": 8,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiHeading.vue"
+          ],
+          "fullName": " UiHeading.vue renders heading tag provided by tag prop",
+          "status": "passed",
+          "title": "renders heading tag provided by tag prop",
+          "duration": 9,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiHeading.vue"
+          ],
+          "fullName": " UiHeading.vue renders different styles for an element when special class is provided",
+          "status": "passed",
+          "title": "renders different styles for an element when special class is provided",
+          "duration": 7,
+          "failureMessages": []
+        }
+      ],
+      "startTime": 1661778043702,
+      "endTime": 1661778043852,
+      "status": "passed",
+      "message": "",
+      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/atoms/UiHeading/UiHeading.spec.js"
+    },
+    {
+      "assertionResults": [
+        {
+          "ancestorTitles": [
+            "",
+            "directive/scrollTabindex"
+          ],
+          "fullName": " directive/scrollTabindex remove tabindex if scrollHeight is lower than clientHeight",
+          "status": "passed",
+          "title": "remove tabindex if scrollHeight is lower than clientHeight",
+          "duration": 92,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "directive/scrollTabindex"
+          ],
+          "fullName": " directive/scrollTabindex adding tabindex if scrollHeight changed",
+          "status": "passed",
+          "title": "adding tabindex if scrollHeight changed",
+          "duration": 6,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "directive/scrollTabindex"
+          ],
+          "fullName": " directive/scrollTabindex remove tabindex if clientHeight changed",
+          "status": "passed",
+          "title": "remove tabindex if clientHeight changed",
+          "duration": 10,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "directive/scrollTabindex"
+          ],
+          "fullName": " directive/scrollTabindex remove tabindex if scrollHeight equals clientHeight",
+          "status": "passed",
+          "title": "remove tabindex if scrollHeight equals clientHeight",
+          "duration": 6,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "directive/scrollTabindex"
+          ],
+          "fullName": " directive/scrollTabindex add tabindex if scrollHeight is greater than clientHeight",
+          "status": "passed",
+          "title": "add tabindex if scrollHeight is greater than clientHeight",
+          "duration": 21,
+          "failureMessages": []
+        }
+      ],
+      "startTime": 1661778043870,
+      "endTime": 1661778044005,
+      "status": "passed",
+      "message": "",
+      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/utilities/directives/scroll-tabindex/scroll-tabindex.spec.js"
+    },
+    {
+      "assertionResults": [
+        {
+          "ancestorTitles": [
+            "",
+            "directive/bodyScrollLock"
+          ],
+          "fullName": " directive/bodyScrollLock The directive add styles to body",
+          "status": "passed",
+          "title": "The directive add styles to body",
+          "duration": 92,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "directive/bodyScrollLock"
+          ],
+          "fullName": " directive/bodyScrollLock The directive removes body styles before the component unmounts",
+          "status": "passed",
+          "title": "The directive removes body styles before the component unmounts",
+          "duration": 15,
+          "failureMessages": []
+        }
+      ],
+      "startTime": 1661778043870,
+      "endTime": 1661778043977,
+      "status": "passed",
+      "message": "",
+      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/utilities/directives/body-scroll-lock/body-scroll-lock.spec.js"
+    },
+    {
+      "assertionResults": [
+        {
+          "ancestorTitles": [
+            "",
+            "UiLoader.vue"
+          ],
+          "fullName": " UiLoader.vue renders a component",
+          "status": "passed",
+          "title": "renders a component",
+          "duration": 62,
+          "failureMessages": []
+        }
+      ],
+      "startTime": 1661778044087,
+      "endTime": 1661778044149,
+      "status": "passed",
+      "message": "",
+      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/molecules/UiLoader/UiLoader.spec.js"
+    },
+    {
+      "assertionResults": [
+        {
+          "ancestorTitles": [
+            "",
+            "UiLink.vue"
+          ],
+          "fullName": " UiLink.vue renders a component",
+          "status": "passed",
+          "title": "renders a component",
+          "duration": 52,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiLink.vue"
+          ],
+          "fullName": " UiLink.vue component is router-link when you pass it a \"to\" prop",
+          "status": "passed",
+          "title": "component is router-link when you pass it a \"to\" prop",
+          "duration": 12,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiLink.vue"
+          ],
+          "fullName": " UiLink.vue component is link when you pass it a  \"href\" propf",
+          "status": "passed",
+          "title": "component is link when you pass it a  \"href\" propf",
+          "duration": 6,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiLink.vue"
+          ],
+          "fullName": " UiLink.vue component is a span without \"to\" and \"href\" props",
+          "status": "passed",
+          "title": "component is a span without \"to\" and \"href\" props",
+          "duration": 4,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiLink.vue"
+          ],
+          "fullName": " UiLink.vue component hasn't link attrs when you put tag",
+          "status": "passed",
+          "title": "component hasn't link attrs when you put tag",
+          "duration": 10,
+          "failureMessages": []
+        }
+      ],
+      "startTime": 1661778046347,
+      "endTime": 1661778046431,
+      "status": "passed",
+      "message": "",
+      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/atoms/UiLink/UiLink.spec.js"
+    },
+    {
+      "assertionResults": [
+        {
+          "ancestorTitles": [
+            "",
+            "UiTextarea.vue"
+          ],
+          "fullName": " UiTextarea.vue renders a component",
+          "status": "passed",
+          "title": "renders a component",
+          "duration": 56,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiTextarea.vue"
+          ],
+          "fullName": " UiTextarea.vue render a native attributes on input element",
+          "status": "passed",
+          "title": "render a native attributes on input element",
+          "duration": 22,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiTextarea.vue"
+          ],
+          "fullName": " UiTextarea.vue a component emits input event",
+          "status": "passed",
+          "title": "a component emits input event",
+          "duration": 10,
+          "failureMessages": []
+        }
+      ],
+      "startTime": 1661778046528,
+      "endTime": 1661778046616,
+      "status": "passed",
+      "message": "",
+      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/atoms/UiTextarea/UiTextarea.spec.js"
     },
     {
       "assertionResults": [
@@ -2673,7 +2757,7 @@
           "fullName": " composable/useActiveElement active item is null when no one items is focused",
           "status": "passed",
           "title": "active item is null when no one items is focused",
-          "duration": 33,
+          "duration": 46,
           "failureMessages": []
         },
         {
@@ -2684,7 +2768,7 @@
           "fullName": " composable/useActiveElement correct active element on focus",
           "status": "passed",
           "title": "correct active element on focus",
-          "duration": 32,
+          "duration": 48,
           "failureMessages": []
         },
         {
@@ -2695,7 +2779,7 @@
           "fullName": " composable/useActiveElement reset active element on blur",
           "status": "passed",
           "title": "reset active element on blur",
-          "duration": 8,
+          "duration": 11,
           "failureMessages": []
         },
         {
@@ -2706,12 +2790,12 @@
           "fullName": " composable/useActiveElement correct update active element",
           "status": "passed",
           "title": "correct update active element",
-          "duration": 10,
+          "duration": 6,
           "failureMessages": []
         }
       ],
-      "startTime": 1661427432263,
-      "endTime": 1661427432346,
+      "startTime": 1661778046687,
+      "endTime": 1661778046799,
       "status": "passed",
       "message": "",
       "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/composable/useActiveElement/useActiveElement.spec.js"
@@ -2726,7 +2810,7 @@
           "fullName": " helpers/focusElement focus element",
           "status": "passed",
           "title": "focus element",
-          "duration": 116,
+          "duration": 143,
           "failureMessages": []
         },
         {
@@ -2737,130 +2821,15 @@
           "fullName": " helpers/focusElement focus element with visible focus",
           "status": "passed",
           "title": "focus element with visible focus",
-          "duration": 8,
+          "duration": 10,
           "failureMessages": []
         }
       ],
-      "startTime": 1661427433003,
-      "endTime": 1661427433127,
+      "startTime": 1661778046834,
+      "endTime": 1661778046987,
       "status": "passed",
       "message": "",
       "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/utilities/helpers/focus-element/focus-element.spec.js"
-    },
-    {
-      "assertionResults": [
-        {
-          "ancestorTitles": [
-            "",
-            "UiLink.vue"
-          ],
-          "fullName": " UiLink.vue renders a component",
-          "status": "passed",
-          "title": "renders a component",
-          "duration": 42,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiLink.vue"
-          ],
-          "fullName": " UiLink.vue component is router-link when you pass it a \"to\" prop",
-          "status": "passed",
-          "title": "component is router-link when you pass it a \"to\" prop",
-          "duration": 6,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiLink.vue"
-          ],
-          "fullName": " UiLink.vue component is link when you pass it a  \"href\" propf",
-          "status": "passed",
-          "title": "component is link when you pass it a  \"href\" propf",
-          "duration": 11,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiLink.vue"
-          ],
-          "fullName": " UiLink.vue component is a span without \"to\" and \"href\" props",
-          "status": "passed",
-          "title": "component is a span without \"to\" and \"href\" props",
-          "duration": 9,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiLink.vue"
-          ],
-          "fullName": " UiLink.vue component hasn't link attrs when you put tag",
-          "status": "passed",
-          "title": "component hasn't link attrs when you put tag",
-          "duration": 9,
-          "failureMessages": []
-        }
-      ],
-      "startTime": 1661427433628,
-      "endTime": 1661427433705,
-      "status": "passed",
-      "message": "",
-      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/atoms/UiLink/UiLink.spec.js"
-    },
-    {
-      "assertionResults": [
-        {
-          "ancestorTitles": [
-            "",
-            "UiLoader.vue"
-          ],
-          "fullName": " UiLoader.vue renders a component",
-          "status": "passed",
-          "title": "renders a component",
-          "duration": 54,
-          "failureMessages": []
-        }
-      ],
-      "startTime": 1661427434121,
-      "endTime": 1661427434175,
-      "status": "passed",
-      "message": "",
-      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/molecules/UiLoader/UiLoader.spec.js"
-    },
-    {
-      "assertionResults": [
-        {
-          "ancestorTitles": [
-            "",
-            "UiMegaMenu.vue"
-          ],
-          "fullName": " UiMegaMenu.vue renders a component",
-          "status": "passed",
-          "title": "renders a component",
-          "duration": 66,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "UiMegaMenu.vue"
-          ],
-          "fullName": " UiMegaMenu.vue component emit item to open",
-          "status": "passed",
-          "title": "component emit item to open",
-          "duration": 43,
-          "failureMessages": []
-        }
-      ],
-      "startTime": 1661427434457,
-      "endTime": 1661427434566,
-      "status": "passed",
-      "message": "",
-      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/organisms/UiMegaMenu/UiMegaMenu.spec.js"
     },
     {
       "assertionResults": [
@@ -2872,15 +2841,46 @@
           "fullName": " UiCard.vue renders a component",
           "status": "passed",
           "title": "renders a component",
-          "duration": 65,
+          "duration": 84,
           "failureMessages": []
         }
       ],
-      "startTime": 1661427434762,
-      "endTime": 1661427434827,
+      "startTime": 1661778046990,
+      "endTime": 1661778047074,
       "status": "passed",
       "message": "",
       "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/organisms/UiCard/UiCard.spec.js"
+    },
+    {
+      "assertionResults": [
+        {
+          "ancestorTitles": [
+            "",
+            "UiMegaMenu.vue"
+          ],
+          "fullName": " UiMegaMenu.vue renders a component",
+          "status": "passed",
+          "title": "renders a component",
+          "duration": 47,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "UiMegaMenu.vue"
+          ],
+          "fullName": " UiMegaMenu.vue component emit item to open",
+          "status": "passed",
+          "title": "component emit item to open",
+          "duration": 11,
+          "failureMessages": []
+        }
+      ],
+      "startTime": 1661778047009,
+      "endTime": 1661778047079,
+      "status": "passed",
+      "message": "",
+      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/organisms/UiMegaMenu/UiMegaMenu.spec.js"
     },
     {
       "assertionResults": [
@@ -2892,15 +2892,35 @@
           "fullName": " UiProgressbar.vue renders a component",
           "status": "passed",
           "title": "renders a component",
-          "duration": 50,
+          "duration": 39,
           "failureMessages": []
         }
       ],
-      "startTime": 1661427434908,
-      "endTime": 1661427434958,
+      "startTime": 1661778047278,
+      "endTime": 1661778047317,
       "status": "passed",
       "message": "",
       "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/molecules/UiProgressbar/UiProgressbar.spec.js"
+    },
+    {
+      "assertionResults": [
+        {
+          "ancestorTitles": [
+            "",
+            "UiContainer.vue"
+          ],
+          "fullName": " UiContainer.vue renders a component",
+          "status": "passed",
+          "title": "renders a component",
+          "duration": 51,
+          "failureMessages": []
+        }
+      ],
+      "startTime": 1661778049367,
+      "endTime": 1661778049418,
+      "status": "passed",
+      "message": "",
+      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/organisms/UiContainer/UiContainer.spec.js"
     },
     {
       "assertionResults": [
@@ -2912,12 +2932,12 @@
           "fullName": " UiList.vue renders a component",
           "status": "passed",
           "title": "renders a component",
-          "duration": 83,
+          "duration": 88,
           "failureMessages": []
         }
       ],
-      "startTime": 1661427435199,
-      "endTime": 1661427435282,
+      "startTime": 1661778049634,
+      "endTime": 1661778049722,
       "status": "passed",
       "message": "",
       "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/organisms/UiList/UiList.spec.js"
@@ -2932,12 +2952,12 @@
           "fullName": " UiProgress.vue renders a component",
           "status": "passed",
           "title": "renders a component",
-          "duration": 50,
+          "duration": 75,
           "failureMessages": []
         }
       ],
-      "startTime": 1661427436031,
-      "endTime": 1661427436081,
+      "startTime": 1661778049678,
+      "endTime": 1661778049753,
       "status": "passed",
       "message": "",
       "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/atoms/UiProgress/UiProgress.spec.js"
@@ -2952,35 +2972,15 @@
           "fullName": " UiText.vue renders a component",
           "status": "passed",
           "title": "renders a component",
-          "duration": 42,
+          "duration": 90,
           "failureMessages": []
         }
       ],
-      "startTime": 1661427436592,
-      "endTime": 1661427436634,
+      "startTime": 1661778049929,
+      "endTime": 1661778050019,
       "status": "passed",
       "message": "",
       "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/atoms/UiText/UiText.spec.js"
-    },
-    {
-      "assertionResults": [
-        {
-          "ancestorTitles": [
-            "",
-            "UiBackdrop.vue"
-          ],
-          "fullName": " UiBackdrop.vue renders a component",
-          "status": "passed",
-          "title": "renders a component",
-          "duration": 86,
-          "failureMessages": []
-        }
-      ],
-      "startTime": 1661427437040,
-      "endTime": 1661427437126,
-      "status": "passed",
-      "message": "",
-      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/atoms/UiBackdrop/UiBackdrop.spec.js"
     },
     {
       "assertionResults": [
@@ -2992,12 +2992,12 @@
           "fullName": " UiIcon.vue renders a component",
           "status": "passed",
           "title": "renders a component",
-          "duration": 47,
+          "duration": 100,
           "failureMessages": []
         }
       ],
-      "startTime": 1661427437387,
-      "endTime": 1661427437434,
+      "startTime": 1661778050000,
+      "endTime": 1661778050100,
       "status": "passed",
       "message": "",
       "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/atoms/UiIcon/UiIcon.spec.js"
@@ -3007,20 +3007,73 @@
         {
           "ancestorTitles": [
             "",
-            "UiContainer.vue"
+            "UiBackdrop.vue"
           ],
-          "fullName": " UiContainer.vue renders a component",
+          "fullName": " UiBackdrop.vue renders a component",
           "status": "passed",
           "title": "renders a component",
-          "duration": 82,
+          "duration": 80,
           "failureMessages": []
         }
       ],
-      "startTime": 1661427437663,
-      "endTime": 1661427437745,
+      "startTime": 1661778050074,
+      "endTime": 1661778050154,
       "status": "passed",
       "message": "",
-      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/organisms/UiContainer/UiContainer.spec.js"
+      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/components/atoms/UiBackdrop/UiBackdrop.spec.js"
+    },
+    {
+      "assertionResults": [
+        {
+          "ancestorTitles": [
+            "",
+            "composable/useMutationObserver"
+          ],
+          "fullName": " composable/useMutationObserver not supported when window doesn't have IntersectionObserver property",
+          "status": "passed",
+          "title": "not supported when window doesn't have IntersectionObserver property",
+          "duration": 8,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "composable/useMutationObserver"
+          ],
+          "fullName": " composable/useMutationObserver no mutation observer added when not supported",
+          "status": "passed",
+          "title": "no mutation observer added when not supported",
+          "duration": 2,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "composable/useMutationObserver"
+          ],
+          "fullName": " composable/useMutationObserver supported when window have property IntersectionObserver",
+          "status": "passed",
+          "title": "supported when window have property IntersectionObserver",
+          "duration": 1,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "composable/useMutationObserver"
+          ],
+          "fullName": " composable/useMutationObserver mutation observer added when supported",
+          "status": "passed",
+          "title": "mutation observer added when supported",
+          "duration": 1,
+          "failureMessages": []
+        }
+      ],
+      "startTime": 1661778050245,
+      "endTime": 1661778050257,
+      "status": "passed",
+      "message": "",
+      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/composable/useMutationObserver/useMutationObserver.spec.js"
     },
     {
       "assertionResults": [
@@ -3032,7 +3085,7 @@
           "fullName": " composable/useLink return correct component tag when parameter has property href",
           "status": "passed",
           "title": "return correct component tag when parameter has property href",
-          "duration": 7,
+          "duration": 4,
           "failureMessages": []
         },
         {
@@ -3043,7 +3096,7 @@
           "fullName": " composable/useLink return correct component tag when parameter has property to",
           "status": "passed",
           "title": "return correct component tag when parameter has property to",
-          "duration": 1,
+          "duration": 0,
           "failureMessages": []
         },
         {
@@ -3054,7 +3107,7 @@
           "fullName": " composable/useLink return correct component tag when parameter has property tag",
           "status": "passed",
           "title": "return correct component tag when parameter has property tag",
-          "duration": 0,
+          "duration": 1,
           "failureMessages": []
         },
         {
@@ -3076,7 +3129,7 @@
           "fullName": " composable/useLink thrown error when parameter is null",
           "status": "passed",
           "title": "thrown error when parameter is null",
-          "duration": 1,
+          "duration": 2,
           "failureMessages": []
         },
         {
@@ -3153,7 +3206,7 @@
           "fullName": " composable/useLink return empty route attrs when parameter property to is undefined",
           "status": "passed",
           "title": "return empty route attrs when parameter property to is undefined",
-          "duration": 0,
+          "duration": 1,
           "failureMessages": []
         },
         {
@@ -3164,68 +3217,15 @@
           "fullName": " composable/useLink return empty route attrs when parameter property to is null",
           "status": "passed",
           "title": "return empty route attrs when parameter property to is null",
-          "duration": 1,
+          "duration": 0,
           "failureMessages": []
         }
       ],
-      "startTime": 1661427437677,
-      "endTime": 1661427437690,
+      "startTime": 1661778052027,
+      "endTime": 1661778052038,
       "status": "passed",
       "message": "",
       "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/composable/useLink/useLink.spec.js"
-    },
-    {
-      "assertionResults": [
-        {
-          "ancestorTitles": [
-            "",
-            "composable/useMutationObserver"
-          ],
-          "fullName": " composable/useMutationObserver not supported when window doesn't have IntersectionObserver property",
-          "status": "passed",
-          "title": "not supported when window doesn't have IntersectionObserver property",
-          "duration": 8,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "composable/useMutationObserver"
-          ],
-          "fullName": " composable/useMutationObserver no mutation observer added when not supported",
-          "status": "passed",
-          "title": "no mutation observer added when not supported",
-          "duration": 11,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "composable/useMutationObserver"
-          ],
-          "fullName": " composable/useMutationObserver supported when window have property IntersectionObserver",
-          "status": "passed",
-          "title": "supported when window have property IntersectionObserver",
-          "duration": 1,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "composable/useMutationObserver"
-          ],
-          "fullName": " composable/useMutationObserver mutation observer added when supported",
-          "status": "passed",
-          "title": "mutation observer added when supported",
-          "duration": 2,
-          "failureMessages": []
-        }
-      ],
-      "startTime": 1661427437977,
-      "endTime": 1661427437999,
-      "status": "passed",
-      "message": "",
-      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/composable/useMutationObserver/useMutationObserver.spec.js"
     },
     {
       "assertionResults": [
@@ -3237,7 +3237,7 @@
           "fullName": " composable/useInput return correct attrs for input element",
           "status": "passed",
           "title": "return correct attrs for input element",
-          "duration": 6,
+          "duration": 7,
           "failureMessages": []
         },
         {
@@ -3281,7 +3281,7 @@
           "fullName": " composable/useInput thrown error when parameter for input element is null",
           "status": "passed",
           "title": "thrown error when parameter for input element is null",
-          "duration": 0,
+          "duration": 6,
           "failureMessages": []
         },
         {
@@ -3318,53 +3318,11 @@
           "failureMessages": []
         }
       ],
-      "startTime": 1661427438512,
-      "endTime": 1661427438521,
+      "startTime": 1661778052044,
+      "endTime": 1661778052060,
       "status": "passed",
       "message": "",
       "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/composable/useInput/useInput.spec.js"
-    },
-    {
-      "assertionResults": [
-        {
-          "ancestorTitles": [
-            "",
-            "composable/useKeyValidation"
-          ],
-          "fullName": " composable/useKeyValidation pressed key is digit",
-          "status": "passed",
-          "title": "pressed key is digit",
-          "duration": 6,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "composable/useKeyValidation"
-          ],
-          "fullName": " composable/useKeyValidation pressed key is different than digit",
-          "status": "passed",
-          "title": "pressed key is different than digit",
-          "duration": 0,
-          "failureMessages": []
-        },
-        {
-          "ancestorTitles": [
-            "",
-            "composable/useKeyValidation"
-          ],
-          "fullName": " composable/useKeyValidation pressed key value length is greater than 1",
-          "status": "passed",
-          "title": "pressed key value length is greater than 1",
-          "duration": 0,
-          "failureMessages": []
-        }
-      ],
-      "startTime": 1661427438919,
-      "endTime": 1661427438926,
-      "status": "passed",
-      "message": "",
-      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/composable/useKeyValidation/useKeyValidation.spec.js"
     },
     {
       "assertionResults": [
@@ -3376,7 +3334,7 @@
           "fullName": " helpers/capitalizeFirst return string with first letter capitalized when first is lowercase",
           "status": "passed",
           "title": "return string with first letter capitalized when first is lowercase",
-          "duration": 7,
+          "duration": 9,
           "failureMessages": []
         },
         {
@@ -3387,7 +3345,7 @@
           "fullName": " helpers/capitalizeFirst return string when first letter is capitalize",
           "status": "passed",
           "title": "return string when first letter is capitalize",
-          "duration": 1,
+          "duration": 0,
           "failureMessages": []
         },
         {
@@ -3398,7 +3356,7 @@
           "fullName": " helpers/capitalizeFirst return string when number is first char",
           "status": "passed",
           "title": "return string when number is first char",
-          "duration": 0,
+          "duration": 1,
           "failureMessages": []
         },
         {
@@ -3464,12 +3422,12 @@
           "fullName": " helpers/capitalizeFirst thrown type error when parameter is type number",
           "status": "passed",
           "title": "thrown type error when parameter is type number",
-          "duration": 0,
+          "duration": 1,
           "failureMessages": []
         }
       ],
-      "startTime": 1661427439175,
-      "endTime": 1661427439184,
+      "startTime": 1661778052138,
+      "endTime": 1661778052150,
       "status": "passed",
       "message": "",
       "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/utilities/helpers/capitalize-first/capitalize-first.spec.js"
@@ -3484,7 +3442,7 @@
           "fullName": " helpers/removeNonDigits given %p as arguments, returns %p  ",
           "status": "passed",
           "title": "given %p as arguments, returns %p  ",
-          "duration": 5,
+          "duration": 9,
           "failureMessages": []
         },
         {
@@ -3495,7 +3453,7 @@
           "fullName": " helpers/removeNonDigits given %p as arguments, returns %p 2e 2",
           "status": "passed",
           "title": "given %p as arguments, returns %p 2e 2",
-          "duration": 1,
+          "duration": 0,
           "failureMessages": []
         },
         {
@@ -3506,7 +3464,7 @@
           "fullName": " helpers/removeNonDigits given %p as arguments, returns %p null null",
           "status": "passed",
           "title": "given %p as arguments, returns %p null null",
-          "duration": 0,
+          "duration": 1,
           "failureMessages": []
         },
         {
@@ -3532,11 +3490,53 @@
           "failureMessages": []
         }
       ],
-      "startTime": 1661427439346,
-      "endTime": 1661427439352,
+      "startTime": 1661778052271,
+      "endTime": 1661778052281,
       "status": "passed",
       "message": "",
       "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/utilities/helpers/remove-non-digits/remove-non-digits.spec.js"
+    },
+    {
+      "assertionResults": [
+        {
+          "ancestorTitles": [
+            "",
+            "composable/useKeyValidation"
+          ],
+          "fullName": " composable/useKeyValidation pressed key is digit",
+          "status": "passed",
+          "title": "pressed key is digit",
+          "duration": 11,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "composable/useKeyValidation"
+          ],
+          "fullName": " composable/useKeyValidation pressed key is different than digit",
+          "status": "passed",
+          "title": "pressed key is different than digit",
+          "duration": 1,
+          "failureMessages": []
+        },
+        {
+          "ancestorTitles": [
+            "",
+            "composable/useKeyValidation"
+          ],
+          "fullName": " composable/useKeyValidation pressed key value length is greater than 1",
+          "status": "passed",
+          "title": "pressed key value length is greater than 1",
+          "duration": 3,
+          "failureMessages": []
+        }
+      ],
+      "startTime": 1661778052297,
+      "endTime": 1661778052312,
+      "status": "passed",
+      "message": "",
+      "name": "/Users/przemyslawspaczek/Projects/symptom-checker-ui-kit/src/composable/useKeyValidation/useKeyValidation.spec.js"
     }
   ]
 }

--- a/src/components/atoms/UiRange/UiRange.vue
+++ b/src/components/atoms/UiRange/UiRange.vue
@@ -6,8 +6,8 @@
     :min="min"
     :max="max"
     :step="step"
-    :button-decrement-attrs="buttonDecrementAttrsExtended"
-    :button-increment-attrs="buttonIncrementAttrsExtended"
+    :button-decrement-attrs="defaultProps.buttonDecrementAttrs"
+    :button-increment-attrs="defaultProps.buttonIncrementAttrs"
     class="ui-range"
     @update:model-value="changeHandler"
   >
@@ -118,19 +118,21 @@ const props = defineProps({
     default: () => ({}),
   },
 });
+const defaultProps = computed(() => ({
+  buttonDecrementAttrs: {
+    'aria-hidden': true,
+    tabindex: -1,
+    ...props.buttonDecrementAttrs,
+  },
+  buttonIncrementAttrs: {
+    'aria-hidden': true,
+    tabindex: -1,
+    ...props.buttonIncrementAttrs,
+  },
+}));
 const attrs = useAttrs();
 const emit = defineEmits<{(e:'update:modelValue', value: number): void}>();
 const { getRootAttrs, getInputAttrs } = useInput();
-const buttonDecrementAttrsExtended = computed(() => ({
-  'aria-hidden': true,
-  tabindex: -1,
-  ...props.buttonDecrementAttrs,
-}));
-const buttonIncrementAttrsExtended = computed(() => ({
-  'aria-hidden': true,
-  tabindex: -1,
-  ...props.buttonIncrementAttrs,
-}));
 const trackWidth = computed(() => {
   const scope = props.max - props.min;
   const position = props.modelValue - props.min;

--- a/src/components/molecules/UiDropdown/_internal/UiDropdownItem.vue
+++ b/src/components/molecules/UiDropdown/_internal/UiDropdownItem.vue
@@ -90,7 +90,7 @@ const buttonAttrs = computed<ButtonAttrs>(() => ({
   --button-border-width: 0;
   --button-color: #{functions.var($element, color, var(--color-text-body))};
   --button-hover-color: #{functions.var($element + "-hover", color, var(--color-text-body))};
-  --button-active-color: #{css-var($element + "-active", color, var(--color-text-body))};
+  --button-active-color: #{functions.var($element + "-active", color, var(--color-text-body))};
   --button-font: #{functions.var($element, font, var(--font-body-1))};
   --button-letter-spacing: #{functions.var($element, letter-spacing, var(--letter-spacing-body-1))};
 

--- a/src/components/molecules/UiNotification/UiNotification.vue
+++ b/src/components/molecules/UiNotification/UiNotification.vue
@@ -23,14 +23,14 @@
           <!-- @slot Use this slot to replace action template.-->
           <slot
             name="action"
-            v-bind="{attrs: buttonActionAttrs, translation, hasAction}"
+            v-bind="{attrs: buttonActionAttrs, translation: defaultProps.translation, hasAction}"
           >
             <UiButton
               v-if="hasAction"
               v-bind="buttonActionAttrs"
               class="ui-button--text ui-button--has-icon ui-notification__action"
             >
-              {{ translation.action }}
+              {{ defaultProps.translation.action }}
               <UiIcon
                 icon="chevron-right"
                 class="ui-button__icon ui-button__icon--right"
@@ -84,6 +84,12 @@ const props = defineProps({
     }),
   },
 });
+const defaultProps = computed(() => ({
+  translation: {
+    action: 'Action',
+    ...props.translation,
+  },
+}));
 const modifier = computed<`ui-notification--${NotificationType}`>(() => `ui-notification--${props.type}`);
 const hasAction = computed(() => (Object.keys(props.buttonActionAttrs).length > 0));
 </script>

--- a/src/components/molecules/UiRating/UiRating.stories.js
+++ b/src/components/molecules/UiRating/UiRating.stories.js
@@ -22,7 +22,6 @@ export default {
     translation: {
       stars: (index) => (`${index} stars`),
     },
-    legend: 'How helpful was this checkup for you?',
   },
   argTypes: {
     initModelValue: {

--- a/src/components/molecules/UiRating/UiRating.vue
+++ b/src/components/molecules/UiRating/UiRating.vue
@@ -22,7 +22,7 @@
       <!-- @slot Use this slot to replace option template. -->
       <slot
         name="option"
-        v-bind="{index, rate, radioAttrs, ratingName, hoverHandler, finalScore, settings, translation}"
+        v-bind="{index, rate, radioAttrs, ratingName, hoverHandler, finalScore, settings, translation: defaultProps.translation}"
       >
         <UiRadio
           v-model="rate"
@@ -66,7 +66,7 @@
             </div>
           </template>
           <template #label>
-            <span class="visual-hidden">{{ translation.stars(index) }}</span>
+            <span class="visual-hidden">{{ defaultProps.translation.stars(index) }}</span>
           </template>
         </UiRadio>
       </slot>
@@ -158,6 +158,11 @@ const props = defineProps({
     default: '',
   },
 });
+const defaultProps = computed(() => ({
+  translation: {
+    stars: (index: number) => (`${index} stars`),
+  },
+}));
 const emit = defineEmits<{(e:'update:modelValue', value: string): void}>();
 const ratingName = computed(() => (
   props.name || `rating-${uid()}`

--- a/src/components/molecules/UiScale/UiScale.stories.js
+++ b/src/components/molecules/UiScale/UiScale.stories.js
@@ -23,7 +23,6 @@ export default {
     },
     buttonDecrementAttrs: { 'aria-label': 'decrement pain' },
     buttonIncrementAttrs: { 'aria-label': 'increment pain' },
-    legend: 'How strong is the headache?',
   },
   argTypes: {
     initModelValue: {
@@ -51,7 +50,6 @@ const Template = (args) => ({
     :legend="legend"
     :steps="steps"
     :translation="translation"
-    :legend="legend"
     :button-decrement-attrs="buttonDecrementAttrs"
     :button-increment-attrs="buttonIncrementAttrs"
   />`,
@@ -70,7 +68,6 @@ export const WithDecrementSlot = (args) => ({
     :name="name"
     :legend="legend"
     :steps="steps"
-    :legend="legend"
     :translation="translation"
     :button-decrement-attrs="buttonDecrementAttrs"
     :button-increment-attrs="buttonIncrementAttrs"
@@ -104,7 +101,6 @@ export const WithIncrementSlot = (args) => ({
     :legend="legend"
     :steps="steps"
     :translation="translation"
-    :legend="legend"
     :button-decrement-attrs="buttonDecrementAttrs"
     :button-increment-attrs="buttonIncrementAttrs"
   >

--- a/src/components/molecules/UiScale/UiScale.vue
+++ b/src/components/molecules/UiScale/UiScale.vue
@@ -2,7 +2,7 @@
   <div
     class="ui-scale"
     role="radiogroup"
-    :aria-label="translation.label"
+    :aria-label="defaultProps.translation.label"
   >
     <component
       :is="tag"
@@ -60,10 +60,10 @@
     </component>
     <div class="ui-scale__description">
       <UiText class="ui-scale__mild">
-        {{ translation.mild }}
+        {{ defaultProps.translation.mild }}
       </UiText>
       <UiText class="ui-scale__unbearable">
-        {{ translation.unbearable }}
+        {{ defaultProps.translation.unbearable }}
       </UiText>
     </div>
     <UiNumberStepper
@@ -71,8 +71,8 @@
       :model-value="scaleValue"
       :min="0"
       :max="steps - 1"
-      :button-decrement-attrs="buttonDecrementAttrsExtended"
-      :button-increment-attrs="buttonIncrementAttrsExtended"
+      :button-decrement-attrs="defaultProps.buttonDecrementAttrs"
+      :button-increment-attrs="defaultProps.buttonIncrementAttrs"
       @update:model-value="changeHandler"
     >
       <template
@@ -169,6 +169,24 @@ const props = defineProps({
     default: '',
   },
 });
+const defaultProps = computed(() => ({
+  translation: {
+    label: 'Pain scale',
+    mild: 'Mild',
+    unbearable: 'Unbearable',
+    ...props.translation,
+  },
+  buttonDecrementAttrs: {
+    'aria-hidden': true,
+    tabindex: -1,
+    ...props.buttonDecrementAttrs,
+  },
+  buttonIncrementAttrs: {
+    'aria-hidden': true,
+    tabindex: -1,
+    ...props.buttonIncrementAttrs,
+  },
+}));
 const emit = defineEmits<{(e: 'update:modelValue', value: number): void}>();
 const scaleName = computed(() => (
   props.name || `scale-${uid()}`
@@ -206,16 +224,6 @@ function calcActiveElementOpacity(index: number): CSSProperties {
     '--_scale-square-overlay-opacity': (index * opacityStepValue).toFixed(3),
   } : {};
 }
-const buttonDecrementAttrsExtended = computed(() => ({
-  'aria-hidden': true,
-  tabindex: -1,
-  ...props.buttonDecrementAttrs,
-}));
-const buttonIncrementAttrsExtended = computed(() => ({
-  'aria-hidden': true,
-  tabindex: -1,
-  ...props.buttonIncrementAttrs,
-}));
 </script>
 
 <style lang="scss">

--- a/src/components/molecules/UiSwitch/_internal/UiSwitchControl.vue
+++ b/src/components/molecules/UiSwitch/_internal/UiSwitchControl.vue
@@ -15,7 +15,7 @@
 
   display: inline-flex;
   width: functions.var($element, width, 2.4rem);
-  border-width: css-var($element, border-width, 2px);
+  border-width: functions.var($element, border-width, 2px);
   border-style: solid;
   border-color: functions.var($element, border-color, var(--_switch-control-color));
   background: functions.var($element, background, var(--_switch-control-color));

--- a/src/components/organisms/UiAccordion/_internal/UiAccordionItem.vue
+++ b/src/components/organisms/UiAccordion/_internal/UiAccordionItem.vue
@@ -3,7 +3,7 @@
     <!-- @slot Use this slot to replace toggler template. -->
     <slot
       name="toggler"
-      v-bind="{ toggle, name, icon, title, isOpen, iconOpen: settings.iconOpen, iconClose: settings.iconClose }"
+      v-bind="{ toggle, name, icon, title, isOpen, iconOpen: defaultProps.settings.iconOpen, iconClose: settings.iconClose }"
     >
       <UiButton
         :id="`toggler${name}`"
@@ -15,7 +15,7 @@
         <!-- @slot Use this slot to replace chevron template. -->
         <slot
           name="chevron"
-          v-bind="{ isOpen, icon, iconOpen: settings.iconOpen, iconClose: settings.iconClose }"
+          v-bind="{ isOpen, icon, iconOpen: defaultProps.settings.iconOpen, iconClose: settings.iconClose }"
         >
           <UiIcon
             :icon="icon"
@@ -78,6 +78,13 @@ const props = defineProps({
     }),
   },
 });
+const defaultProps = computed(() => ({
+  settings: {
+    iconOpen: 'chevron-up',
+    iconClose: 'chevron-down',
+    ...props.settings,
+  },
+}));
 const opened = inject('opened') as ComputedRef<AccordionValue>;
 const toggle = inject('toggle') as (name: string) => void;
 const isOpen = computed(() => {
@@ -86,7 +93,11 @@ const isOpen = computed(() => {
   }
   return opened.value.includes(props.name);
 });
-const icon = computed(() => (isOpen.value ? props.settings.iconOpen : props.settings.iconClose));
+const icon = computed(() => (
+  isOpen.value
+    ? defaultProps.value.settings.iconOpen
+    : defaultProps.value.settings.iconClose
+));
 </script>
 
 <style lang="scss">

--- a/src/components/organisms/UiControls/UiControls.vue
+++ b/src/components/organisms/UiControls/UiControls.vue
@@ -17,14 +17,14 @@
         toNext,
         hideNextButton,
         invalid,
-        translation
+        translation: defaultProps.translation
       }"
     >
       <div class="ui-controls__bottom">
         <!-- @slot Use this slot to replace next template. -->
         <slot
           v-if="toNext"
-          v-bind="{hideNextButton, attrs: nextAttrs, invalid, translation}"
+          v-bind="{hideNextButton, attrs: nextAttrs, invalid, translation: defaultProps.translation}"
           name="next"
         >
           <UiButton
@@ -33,13 +33,13 @@
             class="ui-controls__next"
             :class="{'ui-button--is-disabled': invalid}"
           >
-            {{ translation.next }}
+            {{ defaultProps.translation.next }}
           </UiButton>
         </slot>
         <!-- @slot Use this slot to replace back template. -->
         <slot
           name="back"
-          v-bind="{toBack, attrs: backAttrs, translation}"
+          v-bind="{toBack, attrs: backAttrs, translation: defaultProps.translation}"
         >
           <UiButton
             v-if="toBack"
@@ -49,7 +49,7 @@
             <UiIcon
               icon="chevron-left"
               class="ui-button__icon"
-            /> {{ translation.back }}
+            /> {{ defaultProps.translation.back }}
           </UiButton>
         </slot>
       </div>
@@ -125,6 +125,13 @@ const props = defineProps({
     }),
   },
 });
+const defaultProps = computed(() => ({
+  translation: {
+    back: 'Back',
+    next: 'Next',
+    ...props.translation,
+  },
+}));
 const emit = defineEmits<{(e: 'has-error'): void}>();
 function hasError(): void {
   emit('has-error');

--- a/src/components/organisms/UiDatepicker/UiDatepicker.vue
+++ b/src/components/organisms/UiDatepicker/UiDatepicker.vue
@@ -16,7 +16,7 @@
             :for="getDefaultProp(datePart).id"
             class="ui-datepicker__label"
           >
-            {{ capitalizeFirst(translation[datePart]) }}
+            {{ capitalizeFirst(defaultProps.translation[datePart]) }}
           </UiText>
           <component
             :is="inputComponentSelector(datePart)"
@@ -206,15 +206,29 @@ const getDefaultProps = (datePart: DatePart): DefaultInputProps<DatepickerInputI
   id: `datepicker-input-${datePart}`,
   ...props[`input${capitalizeFirst(datePart) as Capitalize<DatePart>}Attrs`],
 });
-const defaultProps = reactive<{
-  [key in DefaultAttrName]: DefaultInputProps<DatepickerInputID>;
-  }>({
+const defaultProps = computed(() => (
+  {
+    translation: {
+      day: 'day',
+      month: 'month',
+      year: 'year',
+      placeholderDay: 'DD',
+      placeholderMonth: 'MM',
+      placeholderYear: 'YYYY',
+      errorWrongDate: 'Please enter a valid date, e.g. 05/11/1990',
+      errorDateInFuture: 'Sorry, the date of birth cannot be a future date',
+      errorOutOfBounds: 'Sorry, our checkup only covers people between 0 and 120 years old',
+      ...props.translation,
+    },
     inputDayAttrs: getDefaultProps('day'),
     inputMonthAttrs: getDefaultProps('month'),
     inputYearAttrs: getDefaultProps('year'),
-  });
+  }
+));
 const getDefaultProp = (item: DatePart | DefaultAttrName): DefaultInputProps<DatepickerInputID> => (
-  item.includes('Attrs') ? defaultProps[item as DefaultAttrName] : defaultProps[`input${capitalizeFirst(item as DatePart) as Capitalize<DatePart>}Attrs`]);
+  item.includes('Attrs')
+    ? defaultProps.value[item as DefaultAttrName]
+    : defaultProps.value[`input${capitalizeFirst(item as DatePart) as Capitalize<DatePart>}Attrs`]);
 provide('getDefaultProp', getDefaultProp);
 
 const emit = defineEmits<{(e: 'update:modelValue', value: string | null): void,
@@ -477,7 +491,7 @@ watch(isDateValid, (isValid) => {
   emit('update:invalid', !isValid);
 });
 
-provide('translation', props.translation);
+provide('translation', defaultProps.value.translation);
 provide('order', props.order);
 const inputsIds = computed<Record<string, string>>(() => (
   Object.keys(defaultProps).reduce((ids: Record<string, string>, key: string) => {

--- a/src/components/organisms/UiModal/UiModal.vue
+++ b/src/components/organisms/UiModal/UiModal.vue
@@ -93,7 +93,7 @@
           <!-- @slot Use this slot to replace actions template. -->
           <slot
             name="actions"
-            v-bind="{ confirmHandler, cancelHandler, hasActions, hasCancel, hasConfirm, isClosable, translation }"
+            v-bind="{ confirmHandler, cancelHandler, hasActions, hasCancel, hasConfirm, isClosable, translation: defaultProps.translation }"
           >
             <div
               v-if="hasActions"
@@ -103,7 +103,7 @@
                 <!-- @slot Use this slot to replace confirm button template. -->
                 <slot
                   name="confirm"
-                  v-bind="{ attrs: buttonConfirmAttrs, confirmHandler, hasConfirm, translation }"
+                  v-bind="{ attrs: buttonConfirmAttrs, confirmHandler, hasConfirm, translation: defaultProps.translation }"
                 >
                   <UiButton
                     v-if="hasConfirm"
@@ -111,13 +111,13 @@
                     v-bind="buttonConfirmAttrs"
                     @click="confirmHandler"
                   >
-                    {{ translation.confirm }}
+                    {{ defaultProps.translation.confirm }}
                   </UiButton>
                 </slot>
                 <!-- @slot Use this slot to replace cancel button template. -->
                 <slot
                   name="cancel"
-                  v-bind="{ attrs: buttonCancelAttrs, cancelHandler, hasCancel, translation }"
+                  v-bind="{ attrs: buttonCancelAttrs, cancelHandler, hasCancel, translation: defaultProps.translation }"
                 >
                   <UiButton
                     v-if="hasCancel"
@@ -125,7 +125,7 @@
                     v-bind="buttonCancelAttrs"
                     @click="cancelHandler"
                   >
-                    {{ translation.cancel }}
+                    {{ defaultProps.translation.cancel }}
                   </UiButton>
                 </slot>
               </template>
@@ -133,7 +133,7 @@
                 <!-- @slot Use this slot to replace cancel button template. -->
                 <slot
                   name="cancel"
-                  v-bind="{ attrs: buttonCancelAttrs, cancelHandler, hasCancel, translation }"
+                  v-bind="{ attrs: buttonCancelAttrs, cancelHandler, hasCancel, translation: defaultProps.translation }"
                 >
                   <UiButton
                     v-if="hasCancel"
@@ -142,13 +142,13 @@
                     v-bind="buttonCancelAttrs"
                     @click="cancelHandler"
                   >
-                    {{ translation.cancel }}
+                    {{ defaultProps.translation.cancel }}
                   </UiButton>
                 </slot>
                 <!-- @slot Use this slot to replace confirm button template. -->
                 <slot
                   name="confirm"
-                  v-bind="{ attrs: buttonConfirmAttrs, confirmHandler, hasConfirm, translation, }"
+                  v-bind="{ attrs: buttonConfirmAttrs, confirmHandler, hasConfirm, translation: defaultProps.translation }"
                 >
                   <UiButton
                     v-if="hasConfirm"
@@ -156,7 +156,7 @@
                     v-bind="buttonConfirmAttrs"
                     @click="confirmHandler"
                   >
-                    {{ translation.confirm }}
+                    {{ defaultProps.translation.confirm }}
                   </UiButton>
                 </slot>
               </template>
@@ -259,6 +259,13 @@ const props = defineProps({
     default: () => ({ confirm: 'Ok', cancel: 'Cancel' }),
   },
 });
+const defaultProps = computed(() => ({
+  translation: {
+    confirm: 'Ok',
+    cancel: 'Cancel',
+    ...props.translation,
+  },
+}));
 const emit = defineEmits<{(e: 'cancel'): void, (e:'confirm'): void, (e:'update:modelValue', value: boolean): void}>();
 const button = ref<InstanceType<typeof UiButton>|null>(null);
 const hasActions = computed(() => props.hasCancel || props.hasConfirm);

--- a/src/components/organisms/UiMultipleAnswer/UiMultipleAnswer.stories.js
+++ b/src/components/organisms/UiMultipleAnswer/UiMultipleAnswer.stories.js
@@ -90,7 +90,6 @@ export default {
     hint: 'Select one answer',
     touched: false,
     alertHintAttrs: {},
-    legend: 'How long have you had a fever?',
   },
   argTypes: {
     initModelValue: {

--- a/src/components/templates/UiMessage/UiMessage.stories.js
+++ b/src/components/templates/UiMessage/UiMessage.stories.js
@@ -224,11 +224,13 @@ export const AsOffline = (args) => ({
       '--message-illustration-size': '10rem',
     }"
   >
-  <UiText>If you are an administrator of this website, then check your integration settings.</UiText>
-  <UiButton
-    class="ui-button--text"
-    style="margin: var(--space-16) 0 0 0;"
-  >Try again</UiButton>
+    <UiText>If you are an administrator of this website, then check your integration settings.</UiText>
+    <UiButton
+      class="ui-button--text"
+      style="margin: var(--space-16) 0 0 0;"
+    >
+      Try again
+    </UiButton>
   </UiMessage>`,
 });
 AsOffline.args = {


### PR DESCRIPTION
Props in Vue allow setting `default` value. In many cases this will be enough. But not for settings, transitions objects. 

## Example
`translation` in UiScale component.
```js
const props = defineProps({
  translation: {
    type: Object,
    default: () => ({
      label: 'Pain scale',
      mild: 'Mild',
      unbearable: 'Unbearable',
    }),
  },
})
```
To set `label` user should set other values `mild` and `unbearable`.
To solve this issue I add proxy for props call `defaultProxy`
```js
const props = defineProps({
  translation: {
    type: Object,
    default: () => ({
      label: 'Pain scale',
      mild: 'Mild',
      unbearable: 'Unbearable',
    }),
  },
})
const defaultProps = computed(() => ({
  translation: {
    label: 'Pain scale',
    mild: 'Mild',
    unbearable: 'Unbearable',
    ...props.translation,
  },
}));
```
To set `label` user can pass only the `label` value. The other will be the default.