### PR TITLE
feat(accessibility): hide mild and unbearable buttons from screen readers

### DIFF
--- a/src/components/molecules/UiScale/UiScale.vue
+++ b/src/components/molecules/UiScale/UiScale.vue
@@ -59,10 +59,16 @@
       </template>
     </component>
     <div class="ui-scale__description">
-      <UiText class="ui-scale__mild">
+      <UiText
+        class="ui-scale__mild"
+        aria-hidden="true"
+      >
         {{ translation.mild }}
       </UiText>
-      <UiText class="ui-scale__unbearable">
+      <UiText
+        class="ui-scale__unbearable"
+        aria-hidden="true"
+      >
         {{ translation.unbearable }}
       </UiText>
     </div>


### PR DESCRIPTION
in Browse mode, “Mild” and “Unbearable” are read after selecting a value so it may be confusing for screen reader users.