### PR TITLE
fix: remove tsc from check:types script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:unit": "vitest --run",
     "test:watch": "vitest -w --changed",
     "lint": "eslint --fix --ext .js,.vue,.ts src",
-    "check:types": "tsc --noEmit & vue-tsc --noEmit",
+    "check:types": "vue-tsc --noEmit",
     "stylelint": "stylelint src/**/*.{vue,scss,css} --fix",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",


### PR DESCRIPTION
# Related issue
Close #33 

# Scope of work
- fix the problem with incorrect export of types and interfaces by removing `tsc` from the script` check: types`