### PR TITLE
feat: code docs block

### DIFF
--- a/docs/components/Code.jsx
+++ b/docs/components/Code.jsx
@@ -1,0 +1,28 @@
+/* eslint-disable no-param-reassign */
+import React from 'react';
+import { Source } from '@storybook/addon-docs';
+
+const getCodeBlocks = (raw) => {
+  const regex = /(\/\/<Code[\s\S]*?<\/Code>)/mg;
+  return raw.match(regex);
+};
+const getCodeBlocksAsObject = (codeBlocks) => codeBlocks.reduce((blocks, item) => {
+  const regexp = /<Code id="(.*)">([\s\S]*)\/\/<\/Code>/m;
+  const match = item.match(regexp);
+  blocks[match[1]] = match[2];
+  return blocks;
+}, {});
+
+export const Code = ({
+  code = '', id, additionalData = '', language = 'css',
+}) => {
+  if (id) {
+    const codeBlocks = getCodeBlocks(code);
+    const codeBlocksAsObject = getCodeBlocksAsObject(codeBlocks);
+    code = `${additionalData} ${codeBlocksAsObject[id]}`.trim();
+  }
+  return <Source
+    language={language}
+    code={code}
+  />;
+};

--- a/docs/contributing-guide/css-var-deep-dive.stories.mdx
+++ b/docs/contributing-guide/css-var-deep-dive.stories.mdx
@@ -1,5 +1,6 @@
 import { Meta } from '@storybook/addon-docs';
 import { PageOutline } from '../components/PageOutline';
+import { Code } from '../components/Code';
 
 <Meta title="Contributing Guide/CSS Var Deep Dive"/>
 
@@ -11,50 +12,40 @@ CSS Custom Properties (or CSS variables) is powerful solution but it have a few 
 ## How to name CSS variables
 To name CSS variables we base on BEM. `--<block>-<element>-<property>` e.g.
 
-```scss
-.ui-button {
-  color: var(--button-color, var(--color-text-on-action))
-
+<Code code={`.ui-button {
+  color: var(--button-color, var(--color-text-on-action))\n
   &__icon {
     margin: var(--button-icon-margin, 0 0 0 var(--space-4));
   }
-}
-```
+}`}/>
 
 But we have a few additional cases to handle.
 
 ### RTL
 Infermedica Component Library support LTR and RTL languages. Styles base on LTR direction. To handle RTL languages we use `dir="rtl"` e.g.
 
-```scss
-.ui-button {
+<Code code={`.ui-button {
   &__icon {
-    margin: var(--button-icon-margin, 0 0 0 var(--space-4));
-
+    margin: var(--button-icon-margin, 0 0 0 var(--space-4));\n
     [dir="rtl"] & {
       margin: var(--button-rtl-icon-margin, 0 var(--space-4) 0 0);
     }
   }
-}
-
-```
+}`}/>
 
 As you can see on example we add `-rtl` to variable name. `-rtl` will be added only to block.
 
 ### Breakpoints
 Our component library has mobile first styles. In some case we want to change some properties for `tablet` or `desktop` devises. e.g.
 
-```scss
-.ui-tile {
+<Code code={`.ui-tile {
   &__icon {
-    --icon-size: var(--tile-icon-size, 3rem);
-
+    --icon-size: var(--tile-icon-size, 3rem);\n
     @include mixins.from-tablet {
       --icon-size: var(--tile-tablet-icon-size, 4rem);
     }
   }
-}
-```
+}`}/>
 
 As you can see on example we add `-tablet` to variable name. `-<breakpoint-name>` will be added only to block.
 If `-rtl` is exists then `-<breakpoint-name>` will be added after it.
@@ -63,47 +54,38 @@ If `-rtl` is exists then `-<breakpoint-name>` will be added after it.
 
 Components like buttons use `:hover` and `:active` pseudo classes. e.g.
 
-```scss
-.ui-button {
-  background: var(--button-background, var(--color-background-action));
-
+<Code code={`.ui-button {
+  background: var(--button-background, var(--color-background-action));\n
   @media (hover: hover) {
     &:hover {
       background: var(--button-hover-background, var(--color-background-action-hover));
     }
-  }
-
+  }\n
   &:active {
     background: var(--button-active-background, var(--color-background-action-active));
   }
-}
-```
+}`}/>
 
 As you can see on example we add `-hover` and `-active` to variable name. State will be added to element with trigger it.
 
-```scss
-.ui-button {
-  $this: &;
-
+<Code code={`.ui-button {
+  $this: &;\n
   @media (hover: hover) {
     &:hover {
       #{$this}__icon {
         --icon-color: var(--button-hover-icon-color, var(--color-icon-on-action-hover))
       }
     }
-  }
-
+  }\n
   &:active {
     #{$this}__icon {
         --icon-color: var(--button-hover-icon-color, var(--color-icon-on-action-active))
     }
-  }
-
+  }\n
   &__icon {
     --icon-color: var(--button-hover-icon-color, var(--color-icon-on-action))
   }
-}
-```
+}`}/>
 
 As you can se on example we add `-hover` and `-active` after block `button` because the button is te trigger of hover and active state.
 
@@ -111,44 +93,35 @@ As you can se on example we add `-hover` and `-active` after block `button` beca
 
 Component like UiRadio, UiCheckbox and UiTile has `-checked` modifier in variable name e.g.
 
-```scss
-.ui-checkbox {
+<Code code={`.ui-checkbox {
   &__checkbox {
-    background: var(--checkbox-background, var(--color-background-white));
-
+    background: var(--checkbox-background, var(--color-background-white));\n
     &--is-checked {
       background: var(--checkbox-checked-background, var(--color-selectioncontrols-selection));
     }
   }
-}
-```
+}`}/>
 
 ## Why we use a lot of name modifiers?
 When we set custom value for variables you need to create new css class or use existing one like `.ui-button`. e.g.
 
-```scss
-.my-awesome-button {
-  --button-background: var(--color-background-action);
-
+<Code code={`.my-awesome-button {
+  --button-background: var(--color-background-action);\n
   &:hover {
     --button-background: var(--color-background-action-hover);
-  }
-
+  }\n
   &:active {
     --button-background: var(--color-background-action-active);
   }
-}
-```
+}`}/>
 
 But as you can see on example we have a lot unnecessary lines of code. Our approach greatly simplifies this process.
 
-```scss
-.my-awesome-button {
+<Code code={`.my-awesome-button {
   --button-background: var(--color-background-action);
   --button-hover-background: var(--color-background-action-hover);
   --button-active-background: var(--color-background-action-active);
-}
-```
+}`}/>
 
 We can't handle all use cases. When component does not provide the variable you are interested you can set it. Use approach from top of this paragraph.
 
@@ -156,8 +129,7 @@ We can't handle all use cases. When component does not provide the variable you 
 
 Initially, we tried to add CSS variables for all properties that developers want to override in their projects. e.g.
 
-```scss
-.ui-button {
+<Code code={`.ui-button {
   display: var(--button-display, inline-flex);
   width: var(--button-width);
   height: var(--button-height);
@@ -166,62 +138,50 @@ Initially, we tried to add CSS variables for all properties that developers want
   padding: var(--button-padding, var(--space-12) var(--space-32));
   background: var(--button-background, var(--color-background-action));
   color: var(--button-color, var(--color-text-on-action));
-}
-```
+}`}/>
 
 We can't predict all CSS variables developers want to use. We'll have undefined variables anyway.
 That's we use variables only for visual properties like colors, backgrounds, borders (width, radius) and spacers. e.g.
 
-```scss
-.ui-button {
+<Code code={`.ui-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   padding: functions.var($element, padding, var(--space-12) var(--space-32));
   background: functions.var($element, background, var(--color-background-action));
   color: functions.var($element, color, var(--color-text-on-action));
-}
-```
+}`}/>
 
 When you want set others property you can do it anyway.
 
 ## Why we override properties instead of using variables?
 The answer is Specificity and Cascading. When we use variables for e.g hover or modifiers we can't override it in other places. The major reason is Cascading.
 
-```scss
-.ui-button {
-  background: var(--button-background, var(--color-background-action));
-
+<Code code={`.ui-button {
+  background: var(--button-background, var(--color-background-action));\n
   &--outlined {
     --button-background: transparent;
   }
-}
-```
+}`}/>
 
 And we try to override `--button-background` for element with `--outlined` modifier.
 
-```scss
-.ui-alert {
+<Code code={`.ui-alert {
   &__cta {
     --button-background: var(--color-triage-emergency-ambulance);
   }
-}
-```
+}`}/>
 
 Specificity is same but it will be work only when `.ui-alert` styles will be loaded after `.ui-button`. We can't 100% ensure it.
 We build solution resistant to this case and override properties in component.
 
-```scss
-.ui-button {
-  background: var(--button-background, var(--color-background-action));
-
+<Code code={`.ui-button {
+  background: var(--button-background, var(--color-background-action));\n
   &--outlined {
-    background: var(--button-background, transparent);
-
+    background: var(--button-background, transparent);\n
     @include mixins.hover {
       background: var(--button-element-hover-background, var(--color-background-white-hover))
     }
   }
-}
-```
+}`}/>
 

--- a/docs/development-guide/theme-configuration.stories.mdx
+++ b/docs/development-guide/theme-configuration.stories.mdx
@@ -1,5 +1,6 @@
 import { Meta } from '@storybook/addon-docs';
 import { PageOutline } from '../components/PageOutline';
+import { Code } from '../components/Code';
 
 <Meta title="Getting Started/Development Guide/Theme Configuration"/>
 
@@ -24,40 +25,32 @@ Infermedica Component Library uses a few levels to configure the CSS of your pro
 Global variables representing project style guide. They base on the Figma project where we keep Style Library with tokens for color, font, font styles, space, border-radius and more.
 Our tokens used `html` scope to setup default values e.g.
 
-```scss
-html {
+<Code code={`html {
   --space-2: 0.125rem;
-  --space-4: 0.25rem;
-
+  --space-4: 0.25rem;\n
   --border-radius-container: 5px;
   --border-radius-button: 5px;
   --border-radius-form: 5px;
-}
-```
+}`}/>
 
 `html` has lower priority than `:root` scope. So, you can override the default values by adding your own custom properties to `:root` scope e.g.
 
-```scss
-:root {
+<Code code={`:root {
   --border-radius-container: 0;
   --border-radius-button: 0;
   --border-radius-form: 0;
-}
-```
+}`}/>
 
 RTL is supported by adding `:root` scope with `dir: rtl` property e.g.
 
-```scss
-:root {
+<Code code={`:root {
   --font-family-heading: "Roboto", sans-serif;
   --font-family-body: "Roboto", sans-serif;
-}
-
+}\n
 :root[dir="rtl"] {
   --font-family-heading: "IBM Plex Sans Arabic", sans-serif;
   --font-family-body: "IBM Plex Sans Arabic", sans-serif;
-}
-```
+}`}/>
 
 ### Themes
 For styles like `secondary` or `brand` we use themes from BEM convention. Theme is a type of modifiers with have a `-theme-` in name. e.b.
@@ -65,8 +58,7 @@ For styles like `secondary` or `brand` we use themes from BEM convention. Theme 
 
 To set styles for theme, we override the values of default variables using in component. e.g.
 
-```scss
-.ui-button {
+<Code code={`.ui-button {
   @at-root [class*="-secondary"] {
     #{$this},
     &#{$this} {
@@ -78,8 +70,7 @@ To set styles for theme, we override the values of default variables using in co
       --color-icon-primary-active: var(--color-icon-secondary-active);
     }
   }
-}
-```
+}`}/>
 
 The selector used allows to set theme in component. e.g.
 
@@ -104,68 +95,55 @@ You can crete your own themes e.g. dark or light theme.
 Global variables cover many cases. But sometimes you need to configure the CSS of specific components like buttons, icons (e.g. icon sizes), ...
 For example, you may want to change the background color of a every `UiButton` component.
 
-```scss
-.ui-button {
+<Code code={`.ui-button {
   --button-background: #1471C9;
   --button-hover-background: #0F5496;
   --button-active-background: #0B3D6D;
-}
-```
+}`}/>
 
 or size of the icon
 
-```scss
-.ui-icon {
+<Code code={`.ui-icon {
   --icon-size: 1.5rem;
-}
-```
+}`}/>
+
 Component specific variables are defined for customizable properties like color, backgrounds, borders, paddings, margins, etc.
 List of CSS variables for each component is available in the component's documentation.
 
 #### BEM and CSS Custom Properties
 We use BEM naming convention for CSS variables, in common cases is will be `--<block>-<element>-<property>` e.g.
 
-```scss
-.ui-side-panel {
+<Code code={`.ui-side-panel {
   &__content {
    padding: var(--side-panel-content-padding, var(--space-24) var(--space-20));
   }
-}
-```
+}`}/>
 
 But in some case it's not enough.
 
-```scss
-//rtl
+<Code code={`//rtl
 --checkbox-label-margin: 0 0 0 var(--space-12);
---checkbox-rtl-label-margin: 0 var(--space-12) 0 0; // -rtl will be added after block
-
-//breakpoints
---side-panel-content-padding: var(--space-24) var(--space-20);
---side-panel-rtl-tablet-content-padding: var(--space-32) var(--space-48); // <breakpoint> will be added after block if `-rtl` is doesn't exist
-
-//states (hover, active)
---button-icon-color: var(--color-icon-on-action);
---button-hover-icon-color: var(--color-icon-on-action-hover); // <state> will be added after block/element name with used this state i.e. hover is used for button not only for icon
-
-//checked state
---checkbox-checked-background: var(--color-selectioncontrols-selection);
---checkbox-checked-hover-background: var(--color-selectioncontrols-selection-hover); // some components has checked state, it will be added before <state> because checked is more static than temporary states like hover.
-```
+--checkbox-rtl-label-margin: 0 var(--space-12) 0 0; // -rtl will be added after block\n
+  //breakpoints
+  --side-panel-content-padding: var(--space-24) var(--space-20);
+  --side-panel-rtl-tablet-content-padding: var(--space-32) var(--space-48); // breakpoint will be added after block if -rtl is doesn't exist\n
+  //states (hover, active)
+  --button-icon-color: var(--color-icon-on-action);
+  --button-hover-icon-color: var(--color-icon-on-action-hover); // state will be added after block/element name with used this state i.e. hover is used for button not only for icon\n
+  //checked state
+  --checkbox-checked-background: var(--color-selectioncontrols-selection);
+  --checkbox-checked-hover-background: var(--color-selectioncontrols-selection-hover); // some components has checked state, it will be added before state because checked is more static than temporary states like hover.`}/>
 
 CSS Variable cover only design cases i.e. breakpoints, rtl, states is added to required components. When you need to cover new case e.g. new breakpoint you can do it.
 
-``` scss
-@use "@infermedica/component-library/styles/mixins";
-
+<Code code={`@use "@infermedica/component-library/styles/mixins";'\n
 .ui-checkbox {
   &__checkmark {
     @include mixins.for-desktop {
       --icon-size: var(--checkbox-desktop-checkmark-size, 1.5rem);
     }
   }
-}
-```
+}`}/>
 
 More about our CSS Variable and our approach to it you can find in [CSS Variables Deep Diving](docs/contributing-guide-css-var-deep-dive--page).
 
@@ -201,24 +179,20 @@ import { UiButton } from '@infermedica/component-library';
 To configure nested components you should use it CSS Custom Properties. e.g.
 We don't create "proxy variables" for nested Atoms. To configure nested components you should use it variables. e.g.
 
-```scss
-.ui-number-stepper {
+<Code code={`.ui-number-stepper {
   --button-icon-color: #D42E2E;
-}
-```
+}`}/>
 
 But `UiNumberStepper` contain two different buttons. So you can use their own class to override it.
 
-```scss
-.ui-number-stepper {
+<Code code={`.ui-number-stepper {
   &__decrement {
     --button-icon-color: #127F5B;
-  }
+  }\n
   &__increment {
     --button-icon-color: #D42E2E;
   }
-}
-```
+}`}/>
 
 Or you can add custom classes to buttons by props. e.g.
 

--- a/docs/development-guide/working-with-breakpoints.stories.mdx
+++ b/docs/development-guide/working-with-breakpoints.stories.mdx
@@ -1,6 +1,7 @@
 import { Meta } from '@storybook/addon-docs';
 import { PageOutline } from '../components/PageOutline';
 import { Alert } from '../components/Alert';
+import { Code } from '../components/Code';
 
 <Meta title="Getting Started/Development Guide/Working with breakpoints"/>
 
@@ -13,12 +14,11 @@ Infermedica Component Library has a predefined breakpoints but it is possible to
 ## Predefined breakpoints
 Predefined breakpoints in Infermedica Component Library are:
 
-```scss
-$mobile-max-width: 767px !default;
+<Code code={`$mobile-max-width: 767px !default;
 $tablet-min-width: 768px !default;
 $tablet-max-width: 991px !default;
 $desktop-min-width: 992px !default;
-```
+`}/>
 
 <Alert>
   <p>Predefined breakpoints are stored in <code>src/styles/variables/breakpoints.scss</code>.
@@ -84,49 +84,41 @@ export default defineConfig({
 ## Mixins
 To use breakpoints you can use the following mixins:
 
-```scss
-@mixin from($width) {
+<Code code={`@mixin from($width) {
   @media (min-width: $width) {
     @content;
   }
-}
-
+}\n
 @mixin to($width) {
   @media (max-width: $width) {
     @content;
   }
-}
-
+}\n
 @mixin between($min, $max) {
   @media (min-width: $min) and (max-width: $max) {
     @content;
   }
-}
-
+}\n
 @mixin to-mobile {
   @include mixins.to($mobile-max-width) {
     @content;
   }
-}
-
+}\n
 @mixin from-tablet {
   @include mixins.from($tablet-min-width) {
     @content;
   }
-}
-
+}\n
 @mixin from-desktop {
   @include mixins.from($desktop-min-width) {
     @content;
   }
 }
-```
+`}/>
 
 To use breakpoints mixins you should import them in your stylesheet:
 
-```scss
-@use "@symptom-checker/ui-kit/mixins/breakpoints.scss";
-```
+<Code code={`@use "@symptom-checker/ui-kit/mixins/breakpoints.scss";`}/>
 
 ## SASS variables with JavaScript code
 A huge problem in breakpoints is a possibility of using SASS variables in JavaScript code.
@@ -144,16 +136,14 @@ const isMobile = matchMedia(toMobile).matches;
 
 ### Exported breakpoints
 
-```scss
-mobileMaxWidth: $mobile-max-width;
+<Code code={`mobileMaxWidth: $mobile-max-width;
 tabletMinWidth: $tablet-min-width;
 tabletMaxWidth: $tablet-max-width;
 desktopMinWidth: $desktop-min-width;
 toMobile: '(max-width: #{$mobile-max-width})';
 toTablet: '(max-width: #{$tablet-max-width})';
 fromTablet: '(min-width: #{$tablet-min-width})';
-fromDesktop: '(min-width: #{$desktop-min-width})';
-```
+fromDesktop: '(min-width: #{$desktop-min-width})';`} />
 
 Special thanks to @Matteo Fogli and his article [How to share SASS variables with JavaScript code in VueJS](https://dev.to/pecus/how-to-share-sass-variables-with-javascript-code-in-vuejs-55p3).
 
@@ -170,7 +160,7 @@ module.exports = {
           auto: /exports/ // enable CSS module for files from Infermedica Component Library exports directory
         }
       }
-  },
+    },
   },
 }
 ```

--- a/docs/releases/v0.2.x/v0.2.0.stories.mdx
+++ b/docs/releases/v0.2.x/v0.2.0.stories.mdx
@@ -1,4 +1,5 @@
 import { Meta } from '@storybook/addon-docs';
+import { Code } from '../../components/Code';
 
 <Meta title="Releases/v0.2.x/v0.2.0" />
 
@@ -21,12 +22,10 @@ v0.2.0 contains CSS custom properties breaking changes and change names of some 
 - UiTextArea is UiTextarea now [18fcbd6](https://bitbucket.org/infermedica/symptom-checker-ui-kit/commits/18fcbd6d240d2d232bd441a0fc8c73590bae91b0)
 - SC-532: focus is visible only for keyboard navigation
   - to handle focus visible in your app use `.focus-is-hidden` class, added by ui-kit components to body e.g.
-  ```scss
-  .focus-is-hidden {
-    --border-radius-outline: 0;
-    --focus-outer: none;
-  }
-  ```
+  <Code code={`.focus-is-hidden {
+      --border-radius-outline: 0;
+      --focus-outer: none;
+  }`}/>
 - SC-945: use vue-svg-loader instead icons.js file [f320627](https://bitbucket.org/infermedica/symptom-checker-ui-kit/commits/f320627520ce19b08877dc43f041b7d7f58a4dc7)
  - to handle this change you should install vue-svg-loader and setup vue.config.js e.g.
   ```js

--- a/docs/releases/v0.5.x/v0.5.0/migration-guide.stories.mdx
+++ b/docs/releases/v0.5.x/v0.5.0/migration-guide.stories.mdx
@@ -1,6 +1,7 @@
 import { Meta } from '@storybook/addon-docs';
 import { PageOutline } from '../../../components/PageOutline';
 import { Table } from '../../../components/Table';
+import { Code } from '../../../components/Code';
 
 <Meta title="Releases/v0.5.x/v0.5.0/Migration Guide" />
 
@@ -21,27 +22,24 @@ From v0.5.0 we are start to use BEM themes.
 
 We are changing props by props from single component.
 
-```scss
-.ui-button {
+<Code code={`.ui-button {
    &--secondary {
     --button-color: var(--color-text-action-secondary);
     --button-hover-color: var(--color-text-action-secondary-hover);
-    --button-active-color: var(--color-text-action-secondary-active);
-
+    --button-active-color: var(--color-text-action-secondary-active);\n
     &.ui-button--has-icon {
       --button-icon-color: var(--color-icon-secondary);
       --button-icon-color-hover: var(--color-icon-secondary-hover);
       --button-icon-color-active: var(--color-icon-secondary-active);
     }
    }
-}
-```
+}`}/>
 
 **After**
 
 We are changing values of global variables used in component. You can use them in old way, but it is not recommended.
 
-```scss
+<Code code={`
 .ui-button {
   @at-root [className*="-secondary"] {
     #{$this},
@@ -54,8 +52,7 @@ We are changing values of global variables used in component. You can use them i
       --color-icon-primary-active: var(--color-icon-secondary-active);
     }
   }
-}
-```
+}`}/>
 
 ## "Private" CSS Variables
 From v0.5.0 some components has "private" CSS variables. "Private" CSS variables has `_` prefix. This variables shouldn't be used in your project.

--- a/docs/releases/v0.5.x/v0.5.1/migration-guide.stories.mdx
+++ b/docs/releases/v0.5.x/v0.5.1/migration-guide.stories.mdx
@@ -1,5 +1,6 @@
 import { Meta } from '@storybook/addon-docs';
 import { PageOutline } from '../../../components/PageOutline';
+import { Code } from '../../../components/Code';
 
 <Meta title="Releases/v0.5.x/v0.5.1/Migration Guide" />
 
@@ -14,25 +15,20 @@ From v0.5.1 we use SASS `@use` instead `@import` because `@import` will be dropp
 
 **Before**
 
-```scss
-@import "../../../styles/mixins/mixins";
-@import "../../../styles/functions/functions";
-
+<Code code={`@import "../../../styles/mixins/mixins";
+@import "../../../styles/functions/functions";\n
 .ui-component {
   $element: component;
   @include font($element, button-1);
   padding: css-var($element, padding, var(--space-12) var(--space-32));
-}
-```
+}`}/>
 
 **After**
-```scss
-@use "../../../styles/functions";
-@use "../../../styles/mixins";
-
+<Code code={`@use "../../../styles/functions";
+@use "../../../styles/mixins";\n
 .ui-component {
   $element: component;
   @include mixins.font($element, button-1);
   padding: functions.var($element, padding, var(--space-12) var(--space-32));
 }
-```
+`}/>

--- a/src/components/molecules/UiHeader/UiHeader.mdx
+++ b/src/components/molecules/UiHeader/UiHeader.mdx
@@ -1,0 +1,52 @@
+import { Canvas, Meta, Story, Primary, ArgsTable } from "@storybook/addon-docs";
+import { Code } from '../../../../docs/components/Code';
+import UiHeader from "./UiHeader.vue";
+import scss from './UiHeader.stories.scss?raw';
+
+<Meta title="Molecules/UiHeader" component={UiHeader} />
+
+# UiHeader
+<Primary />
+<ArgsTable />
+
+## Stories
+### Hamburger Menu Always Displayed
+<Canvas>
+  <Story id="molecules-header--hamburger-menu-always-display"/>
+</Canvas>
+
+### Without Hamburger Menu
+<Canvas>
+  <Story id="molecules-header--without-hamburger-menu"/>
+</Canvas>
+
+### With Brand Slot
+<Canvas>
+  <Story id="molecules-header--with-brand-slot"/>
+</Canvas>
+
+### With Logo Slot
+<Canvas>
+  <Story id="molecules-header--with-logo-slot"/>
+</Canvas>
+
+### With Hamburger Slot
+<Canvas>
+  <Story id="molecules-header--with-hamburger-slot"/>
+</Canvas>
+
+### With Navigation Slot
+<Canvas>
+  <Story id="molecules-header--with-navigation-slot"/>
+</Canvas>
+
+### With Custom Brand
+<Canvas>
+  <Story id="molecules-header--with-custom-brand"/>
+</Canvas>
+
+**Use following SCSS to get the same result**
+<Code
+  id="header-custom-brand"
+  code={scss}
+/>

--- a/src/components/molecules/UiHeader/UiHeader.stories.js
+++ b/src/components/molecules/UiHeader/UiHeader.stories.js
@@ -7,6 +7,7 @@ import { defineAsyncComponent } from 'vue';
 import { actions } from '@storybook/addon-actions';
 import { modifiers } from '@sb/helpers/argTypes';
 import { toMobile } from '../../../styles/exports/breakpoints.module.scss';
+import docs from './UiHeader.mdx';
 
 const events = actions({
   onClickBrandButton: 'click:brand-button',
@@ -49,7 +50,7 @@ export default {
     navigationAttrs: { 'data-testid': 'navigation' },
   },
   argTypes: {
-    modifiers: modifiers({ options: [ 'ui-header--full' ] }),
+    modifiers: modifiers({ options: [ 'ui-header--full-width' ] }),
     logo: {
       description: 'Use this prop to set the logo.',
       control: false,
@@ -82,6 +83,7 @@ export default {
     iconLogoAttrs: { table: { subcategory: 'Attrs props' } },
     navigationAttrs: { table: { subcategory: 'Attrs props' } },
   },
+  parameters: { docs: { page: docs } },
 };
 
 const Template = (args) => ({
@@ -305,16 +307,7 @@ export const WithCustomBrand = (args) => ({
       logo,
     };
   },
-  template: `<div :style="{
-    '--color-background-brand': '#FFF', 
-    '--color-icon-on-brand': '#1F262C', 
-    '--color-icon-on-brand-hover': '#1F262C',
-    '--color-icon-on-brand-active': '#1F262C',
-    '--color-text-on-brand': '#1F262C',
-    '--color-text-on-brand-hover': '#1F262C', 
-    '--color-text-on-brand-active': '#1F262C'
-  }">
-    <UiHeader
+  template: `<UiHeader
       :title="title"
       :logo="logo"
       :hamburgerMatchMedia="hamburgerMatchMedia"
@@ -324,9 +317,8 @@ export const WithCustomBrand = (args) => ({
       :icon-hamburger-attrs="iconHamburgerAttrs"
       :icon-logo-attrs="iconLogoAttrs"
       :navigation-attrs="navigationAttrs"
-      :class="modifiers"
+      :class="['header-custom-brand', modifiers]"
       @hamburger:close="onHamburgerClose"
       @hamburger:open="onHamburgerOpen"
-    />
-  </div>`,
+  />`,
 });

--- a/src/components/molecules/UiHeader/UiHeader.stories.scss
+++ b/src/components/molecules/UiHeader/UiHeader.stories.scss
@@ -1,9 +1,11 @@
-[class$="--theme-on-brand"] {
-  .ui-button {
-    &--text {
-      --button-color: var(--color-text-on-brand);
-      --button-hover-color: var(--color-text-on-brand-hover);
-      --button-action-color: var(--color-text-on-brand-action);
-    }
-  }
+//<Code id="header-custom-brand">
+.header-custom-brand {
+  --color-background-brand: #FFF;
+  --color-icon-on-brand: #1F262C;
+  --color-icon-on-brand-hover: #1F262C;
+  --color-icon-on-brand-active: #1F262C;
+  --color-text-on-brand: #1F262C;
+  --color-text-on-brand-hover: #1F262C;
+  --color-text-on-brand-active: #1F262C;
 }
+//</Code>

--- a/src/components/molecules/UiInteractiveSvg/UiInteractiveSvg.mdx
+++ b/src/components/molecules/UiInteractiveSvg/UiInteractiveSvg.mdx
@@ -1,5 +1,7 @@
-import { Canvas, Meta, Story, Primary, ArgsTable, Source } from "@storybook/addon-docs";
+import { Canvas, Meta, Story, Primary, ArgsTable } from "@storybook/addon-docs";
+import { Code } from '../../../../docs/components/Code';
 import UiInteractiveSvg from "./UiInteractiveSvg.vue";
+import scss from './UiInteractiveSvg.stories.scss?raw';
 
 <Meta title="Molecules/UiInteractiveSvg" component={UiInteractiveSvg} />
 
@@ -15,63 +17,12 @@ import UiInteractiveSvg from "./UiInteractiveSvg.vue";
 
 Some groups have `focus-for` attribute. We use it to show an outline for the focused element.
 
-To style the map, you can use the following SCSS.
-
-```scss
-@use "@infermedica/component-library/mixins";
-
-.map {
-  &__region {
-    cursor: pointer;
-    fill: #2f91ea;
-    stroke: #1471c9;
-
-    &:focus {
-      outline: none;
-      stroke: white;
-    }
-
-    @include mixins.hover {
-      fill: #a2cff5;
-    }
-
-    &--is-checked {
-      fill: #0b3d6d;
-      stroke: #2f91ea;
-
-      @include mixins.hover {
-        fill: #082c4d;
-      }
-
-    }
-  }
-
-  &__focus-for-region {
-    pointer-events: none;
-    visibility: hidden;
-    fill: transparent;
-    stroke-linejoin: round;
-
-    path:first-of-type {
-      stroke: white;
-      stroke-width: 6px;
-    }
-
-    path:last-of-type {
-      stroke: #2f91ea;
-      stroke-width: 2px;
-    }
-
-    &--is-focused {
-      visibility: visible;
-    }
-  }
-
-  &__outline {
-    fill: white;
-  }
-}
-```
+**Use following SCSS to get the same result**
+<Code
+  id="map"
+  code={scss}
+  additionalData={'@infermedica/component-library/mixins\n'}
+/>
 
 ### Abdominal Pain Male
 <Canvas>
@@ -80,51 +31,12 @@ To style the map, you can use the following SCSS.
 
 Some groups have `focus-for` attribute. We use it to show an outline for the focused element.
 
-To style the abdominal pain, you can use the following SCSS.
-
-```scss
-@use "@infermedica/component-library/mixins";
-
-.abdominal-pain {
-  &__part {
-    cursor: pointer;
-    fill: #2f91ea;
-
-    &:focus {
-      outline: none;
-    }
-
-    @include mixins.hover {
-      fill: #1471c9;
-    }
-
-    &--is-checked {
-      fill: #0b3d6d;
-
-      @include mixins.hover {
-        fill: #082c4d;
-      }
-    }
-  }
-
-  &__focus-for-part {
-    pointer-events: none;
-    visibility: hidden;
-    fill: transparent;
-    stroke: white;
-    stroke-width: 2px;
-
-    &--is-focused {
-      visibility: visible;
-    }
-  }
-
-  &__outline {
-    pointer-events: none;
-    fill: #0f5496;
-  }
-}
-```
+**Use following SCSS to get the same result**
+<Code
+  id="abdominal-pain"
+  code={scss}
+  additionalData={'@infermedica/component-library/mixins\n'}
+/>
 
 ### Abdominal Pain Female
 <Canvas>
@@ -136,39 +48,12 @@ To style the abdominal pain, you can use the following SCSS.
   <Story id="molecules-interactivesvg--infant-unisex-front"/>
 </Canvas>
 
-To style the body model, you can use the following SCSS.
-
-```scss
-@use "@infermedica/component-library/mixins";
-
-.body-model {
-  &__part {
-    cursor: pointer;
-    fill: #c2e0f8;
-
-    @include mixins.from-tablet {
-      fill: transparent;
-    }
-
-    @include mixins.hover {
-      fill: #71b5f0;
-    }
-
-    &--is-selected {
-      fill: #c2e0f8;
-    }
-
-    &--is-highlighted {
-      fill: #71b5f0;
-    }
-  }
-
-  &__outline {
-    pointer-events: none;
-    fill: #1471c9;
-  }
-}
-```
+**Use following SCSS to get the same result**
+<Code
+  id="body-model"
+  code={scss}
+  additionalData={'@infermedica/component-library/mixins\n'}
+/>
 
 ### Infant Unisex Back
 <Canvas>

--- a/src/components/molecules/UiInteractiveSvg/UiInteractiveSvg.stories.scss
+++ b/src/components/molecules/UiInteractiveSvg/UiInteractiveSvg.stories.scss
@@ -1,5 +1,6 @@
 @use "../../../styles/mixins";
 
+//<Code id="map">
 .map {
   &__region {
     cursor: pointer;
@@ -51,7 +52,9 @@
     fill: white;
   }
 }
+//</Code>
 
+//<Code id="abdominal-pain">
 .abdominal-pain {
   &__part {
     cursor: pointer;
@@ -92,7 +95,9 @@
     fill: #0f5496;
   }
 }
+//</Code>
 
+//<Code id="body-model">
 .body-model {
   &__part {
     cursor: pointer;
@@ -120,4 +125,5 @@
     fill: #1471c9;
   }
 }
+//</Code>
 

--- a/src/components/molecules/UiLoader/UiLoader.mdx
+++ b/src/components/molecules/UiLoader/UiLoader.mdx
@@ -1,6 +1,8 @@
 import { Canvas, Meta, Story, Primary, ArgsTable, Source } from "@storybook/addon-docs";
 import { Alert } from "../../../../docs/components/Alert"
+import { Code } from '../../../../docs/components/Code';
 import UiLoader from "./UiLoader.vue";
+import scss from './UiLoader.stories.scss?raw';
 
 <Meta title="MoleculesUiLoader" component={UiLoader} />
 
@@ -69,6 +71,12 @@ It's useful for buttons with loading state.
   <Story id="molecules-loader--loading-popover"/>
 </Canvas>
 
+**Use following SCSS to get the same result**
+<Code
+  id="loading-popover"
+  code={scss}
+/>
+
 ### Loading Container
 <Canvas>
   <Story id="molecules-loader--loading-container"/>
@@ -78,6 +86,12 @@ It's useful for buttons with loading state.
 <Canvas>
   <Story id="molecules-loader--loading-side-panel"/>
 </Canvas>
+
+**Use following SCSS to get the same result**
+<Code
+  id="loading-side-panel"
+  code={scss}
+/>
 
 ### Loading Controls
 <Canvas>

--- a/src/components/molecules/UiLoader/UiLoader.stories.scss
+++ b/src/components/molecules/UiLoader/UiLoader.stories.scss
@@ -1,5 +1,6 @@
+//<Code id="loading-popover">
 .loading-popover {
-  --popover-content-padding: 0 1rem;
+  --popover-content-padding: 0 var(--space-16);
 
   max-width: 25rem;
   min-height: 18rem;
@@ -12,14 +13,16 @@
     --message-content-align-self: flex-start;
     --message-illustration-size: 1.5rem;
 
-    margin: 1rem 0;
+    margin: var(--space-16) 0;
   }
 
   &__try-again {
-    margin: 1rem 0;
+    margin: var(--space-16) 0;
   }
 }
+//</Code>
 
+//<Code id="loading-side-panel">
 .loading-side-panel {
   &__message {
     --message-flex-direction: row-reverse;
@@ -31,6 +34,7 @@
   }
 
   &__try-again {
-    margin: 1rem 0;
+    margin: var(--space-16) 0;
   }
 }
+//</Code>

--- a/src/components/organisms/UiMenu/UiMenu.mdx
+++ b/src/components/organisms/UiMenu/UiMenu.mdx
@@ -1,0 +1,43 @@
+import { Canvas, Meta, Story, Primary, ArgsTable } from '@storybook/addon-docs';
+import { Code } from '../../../../docs/components/Code';
+import UiMenu from './UiMenu.vue';
+import scss from './UiMenu.stories.scss?raw';
+
+<Meta title="OrganismsUiMenu" component={UiMenu} />
+
+# UiMenu
+<Primary />
+<ArgsTable />
+
+## Stories
+### As Compact
+<Canvas>
+  <Story id="organisms-menu--as-compact"/>
+</Canvas>
+
+### With Items As String
+<Canvas>
+  <Story id="organisms-menu--with-items-as-string"/>
+</Canvas>
+
+### With Suffix
+<Canvas>
+  <Story id="organisms-menu--with-suffix"/>
+</Canvas>
+
+### As Side Panel
+<Canvas>
+  <Story id="organisms-menu--as-side-panel"/>
+</Canvas>
+
+**Use following SCSS to get the same result**
+<Code
+  id="menu-side-panel"
+  code={scss}
+  additionalData={'@infermedica/component-library/mixins\n'}
+/>
+
+### As Popover Content
+<Canvas>
+  <Story id="organisms-menu--as-popover-content"/>
+</Canvas>

--- a/src/components/organisms/UiMenu/UiMenu.stories.js
+++ b/src/components/organisms/UiMenu/UiMenu.stories.js
@@ -11,6 +11,7 @@ import UiPopover from '@/components/molecules/UiPopover/UiPopover.vue';
 import UiSidePanel from '@/components/organisms/UiSidePanel/UiSidePanel.vue';
 import './UiMenu.stories.scss';
 import { modifiers } from '@sb/helpers/argTypes';
+import docs from './UiMenu.mdx';
 
 export default {
   title: 'Organisms/Menu',
@@ -36,6 +37,7 @@ export default {
   },
   argTypes: { modifiers: modifiers({ options: [ 'ui-menu--compact' ] }) },
   decorators: [ () => ({ template: '<div style="max-width: 21.875rem"><story /></div>' }) ],
+  parameters: { docs: { page: docs } },
 };
 
 const Template = (args) => ({

--- a/src/components/organisms/UiMenu/UiMenu.stories.scss
+++ b/src/components/organisms/UiMenu/UiMenu.stories.scss
@@ -1,5 +1,6 @@
 @use "../../../styles/mixins";
 
+//<Code id="menu-side-panel">
 .menu-side-panel {
   --side-panel-content-padding: 0;
   --side-panel-tablet-content-padding: 0;
@@ -17,3 +18,4 @@
     padding: var(--space-24) var(--space-20) var(--space-40);
   }
 }
+//</Code>


### PR DESCRIPTION
# Related issue
Close

# Scope of work

* Add `Code` to Storybook Doc Blocks
* Use `Code` to scrap `*.stories.scss` and display SCSS
* Use `Code` in docs instead `'''scss'''` to support highlighting

# How to use 
```scss
//.stories.scss
// <Code id="header-custom-brand">
.header-custom-brand {}
// </Code>
```

```jsx
//.mdx
import scss from '*.stories.scss?raw'
...
<Code
  id="header-custom-brand"
  code={scss}
/>
```
# Screenshots of visual changes
**Before**
![Zrzut ekranu 2022-11-8 o 11 45 40](https://user-images.githubusercontent.com/12138170/200545384-5fff3f30-28c9-4893-a021-77cc130a97d1.png)

**After**
![Zrzut ekranu 2022-11-8 o 11 44 51](https://user-images.githubusercontent.com/12138170/200545385-81df10d6-f676-4bb3-adb4-8ee8b218c058.png)