### PR TITLE
fix: hover action in UiRating and UiScale it doesn't works

### DIFF
--- a/src/components/atoms/UiCheckbox/UiCheckbox.vue
+++ b/src/components/atoms/UiCheckbox/UiCheckbox.vue
@@ -2,7 +2,10 @@
   <label
     class="ui-checkbox"
     :for="checkboxId"
-    v-bind="attrs"
+    v-bind="{
+      ...attrs,
+      ...elementsListeners.label
+    }"
   >
     <input
       :id="checkboxId"
@@ -142,6 +145,18 @@ const props = defineProps({
 const {
   attrs, listeners,
 } = useAttributes();
+const elementsListeners = computed(() => {
+  const {
+    onFocus, onBlur, ...rest
+  } = listeners.value;
+  return {
+    input: {
+      onFocus,
+      onBlur,
+    },
+    label: rest,
+  };
+});
 const defaultProps = computed(() => ({
   iconCheckmarkAttrs: {
     icon: 'checkmark' as Icon,
@@ -153,7 +168,7 @@ const defaultProps = computed(() => ({
   },
   inputAttrs: {
     disabled: props.disabled,
-    ...listeners.value,
+    ...elementsListeners.value.input,
     ...props.inputAttrs,
   },
 }));

--- a/src/components/atoms/UiRadio/UiRadio.vue
+++ b/src/components/atoms/UiRadio/UiRadio.vue
@@ -2,7 +2,10 @@
   <label
     class="ui-radio"
     :for="radioId"
-    v-bind="attrs"
+    v-bind="{
+      ...attrs,
+      ...elementsListeners.label
+    }"
   >
     <input
       :id="radioId"
@@ -133,6 +136,18 @@ const props = defineProps({
 const {
   attrs, listeners,
 } = useAttributes();
+const elementsListeners = computed(() => {
+  const {
+    onFocus, onBlur, ...rest
+  } = listeners.value;
+  return {
+    input: {
+      onFocus,
+      onBlur,
+    },
+    label: rest,
+  };
+});
 const defaultProps = computed(() => ({
   textLabelAttrs: {
     tag: 'span' as HTMLTag,
@@ -140,7 +155,7 @@ const defaultProps = computed(() => ({
   },
   inputAttrs: {
     disabled: props.disabled,
-    ...listeners.value,
+    ...elementsListeners.value.input,
     ...props.inputAttrs,
   },
 }));

--- a/src/components/molecules/UiRating/UiRating.stories.js
+++ b/src/components/molecules/UiRating/UiRating.stories.js
@@ -56,7 +56,7 @@ const Template = (args) => ({
     :translation="translation"
     :radio-option-attrs="radioOptionAttrs"
     :class="modifiers"
-  />{{modelValue}}`,
+  />`,
 });
 
 export const Common = Template.bind({});


### PR DESCRIPTION
# Related issue
Close #67 

# Scope of work
* UiCheckbox and UiRadio `<input/>` handle only `focus` and `blur` listeners. Other listeners are passed to the label.

`<input/>` is visual-hidden and it handle only `focus` and `blur` listeners 

# Screenshots of visual changes
**UiScale**
![Kapture 2022-12-12 at 12 39 03](https://user-images.githubusercontent.com/12138170/207036350-5817bf72-66d0-49da-b876-fdcba5ec5c0d.gif)
**UiRating**
![Kapture 2022-12-12 at 12 42 18](https://user-images.githubusercontent.com/12138170/207036696-1726c9ca-da76-45aa-8f7b-c9dbacfeeb65.gif)
