### PR TITLE
refactor: run only test on pre-push

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,6 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npm run test:generate-output && npm run create:icons-list && npm run create:index
-git add .unit-test-results.json index.ts ./src/components/atoms/UiIcon/icons.ts
-git commit -m "chore: update auto-generated files"
+npm run test:unit

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "create:component": "node scripts/create-component.mjs",
     "create:icons-list": "node scripts/create-icons-list.mjs",
     "create:release-notes": "node --experimental-fetch scripts/create-release-notes.mjs",
+    "prerelease": "pnpm run create:index && pnpm run create:icons-list && pnpm run test:generate-output",
     "release": "node --experimental-fetch scripts/release.mjs",
     "update:docs": "node scripts/update-components-docs.mjs && pnpm lint",
     "update:components-api": "node scripts/update-components-api.mjs",


### PR DESCRIPTION
I think pre-push is not the best place to run these scripts :( My idea fails. Now it should be better. 
* `test` on pre-push will prevent push code with failing tests to the repository. 
* `create:index`, `create:icons-list`, and `test:generate-output` can be run before release to keep it updated. 
* `create:index` will be run after `create:component`