### PR TITLE
fix: useLink composable uses aliased import

### DIFF
--- a/src/composable/useLink/index.ts
+++ b/src/composable/useLink/index.ts
@@ -1,6 +1,6 @@
 import { computed } from 'vue';
-import type { ButtonProps } from '@/components/atoms/UiButton/UiButton.vue';
-import type { LinkProps } from '@/components/atoms/UiLink/UiLink.vue';
+import type { ButtonProps } from '../../components/atoms/UiButton/UiButton.vue';
+import type { LinkProps } from '../../components/atoms/UiLink/UiLink.vue';
 
 export default function useLink(props: ButtonProps | LinkProps) {
   const componentTag = computed(() => {


### PR DESCRIPTION
# Related
Closes #130 

# Scope of work
- Set relative import instead of aliased in `useLink` composable