### PR TITLE
fix: shrinking multiple choices item radio buttons

### DIFF
--- a/src/components/organisms/UiMultipleChoices/UiMultipleChoices.stories.js
+++ b/src/components/organisms/UiMultipleChoices/UiMultipleChoices.stories.js
@@ -81,14 +81,10 @@ export default {
   },
   parameters: {
     cssProperties: {
-      '--multiple-choices-hint-padding-block':
-        'var(--multiple-choices-hint-padding-block-start, 0) var(--multiple-choices-hint-padding-block-end, var(--space-12))',
-      '--multiple-choices-hint-padding-inline':
-        'var(--multiple-choices-hint-padding-inline-start, var(--space-20)) var(--multiple-choices-hint-padding-inline-end, var(--space-20))',
-      '--multiple-choices-tablet-hint-padding-block':
-        'var(--multiple-choices-tablet-hint-padding-block-start, 0) var(--multiple-choices-tablet-hint-padding-block-end, var(--space-12))',
-      '--multiple-choices-tablet-hint-padding-inline':
-        'var(--multiple-choices-tablet-hint-padding-inline-start, 0) var(--multiple-choices-tablet-hint-padding-inline-end, 0)',
+      '--multiple-choices-hint-padding-block': 'var(--multiple-choices-hint-padding-block-start, 0) var(--multiple-choices-hint-padding-block-end, var(--space-12))',
+      '--multiple-choices-hint-padding-inline': 'var(--multiple-choices-hint-padding-inline-start, var(--space-20)) var(--multiple-choices-hint-padding-inline-end, var(--space-20))',
+      '--multiple-choices-tablet-hint-padding-block': 'var(--multiple-choices-tablet-hint-padding-block-start, 0) var(--multiple-choices-tablet-hint-padding-block-end, var(--space-12))',
+      '--multiple-choices-tablet-hint-padding-inline': 'var(--multiple-choices-tablet-hint-padding-inline-start, 0) var(--multiple-choices-tablet-hint-padding-inline-end, 0)',
     },
   },
 };

--- a/src/components/organisms/UiMultipleChoices/_internal/UiMultipleChoicesItem.vue
+++ b/src/components/organisms/UiMultipleChoices/_internal/UiMultipleChoicesItem.vue
@@ -366,6 +366,7 @@ const optionsToRender = computed(() => props.options.map((option) => ({ ...optio
   &__choices {
     display: flex;
     flex-direction: column;
+    flex-shrink: 0;
     gap: functions.var($element + "-choices", gap, 0);
 
     @include mixins.from-tablet {
@@ -385,7 +386,7 @@ const optionsToRender = computed(() => props.options.map((option) => ({ ...optio
   }
 
   &__option-content {
-    @include mixins.override-logical(list-item, $element + "-option-content", padding);
+    @include mixins.override-logical(list-item-content, $element + "-option-content", padding);
     @include mixins.override-logical(list-item-tablet-content, $element + "-tablet-option-content", padding, 0);
     --list-item-content-hover-background: #{functions.var($element + "-content-hover", background)};
   }


### PR DESCRIPTION
# Related
Closes #132   

# Scope of work
- Prevent shrinking multiple choices item radio buttons
- Fixing incorrect mobile padding override for `.ui-multiple-choices-item__option-content` element.