### PR TITLE
fix: broken mobile layout if UiMultipleChoices on Safari

### DIFF
--- a/src/components/organisms/UiMultipleChoices/_internal/UiMultipleChoicesItem.vue
+++ b/src/components/organisms/UiMultipleChoices/_internal/UiMultipleChoicesItem.vue
@@ -375,18 +375,30 @@ const optionsToRender = computed(() => props.options.map((option) => ({ ...optio
   }
 
   &__options {
-    @include mixins.override-logical(list-item, $element + "-options", border-width);
-
     @include mixins.from-tablet {
-      @include mixins.override-logical(list-item, $element + "-tablet-options", border-width, 0);
-
       display: flex;
       gap: functions.var($element + "-options", gap, var(--space-24));
     }
   }
 
+  &__option {
+    @include mixins.override-logical(list-item, $element + "-option", border-width,  1px 0 0 0);
+
+    &:last-of-type {
+      @include mixins.override-logical(list-item, $element + "-option", border-width,  1px 0);
+    }
+
+    @include mixins.from-tablet {
+      @include mixins.override-logical(list-item, $element + "-tablet-option", border-width, 0);
+
+      &:last-of-type {
+        @include mixins.override-logical(list-item, $element + "-tablet-option", border-width, 0);
+      }
+    }
+  }
+
   &__option-content {
-    @include mixins.override-logical(list-item-content, $element + "-option-content", padding);
+    @include mixins.override-logical(list-item-content, $element + "-option-content", padding, var(--space-12) var(--space-20));
     @include mixins.override-logical(list-item-tablet-content, $element + "-tablet-option-content", padding, 0);
 
     --list-item-content-hover-background: #{functions.var($element + "-content-hover", background)};


### PR DESCRIPTION
# Related issue
Close #156 

# Scope of work
- fix UiMultipleChoicesItem styles on Safari; Paddings and borders are 

# Screenshots of visual changes
![Zrzut ekranu 2023-05-8 o 09 43 00](https://user-images.githubusercontent.com/12138170/236774540-9f719374-e391-4759-9a69-596b0501c179.png)
