### PR TITLE
fix: missing focus outline in UiRating

### DIFF
--- a/src/components/molecules/UiRating/UiRating.vue
+++ b/src/components/molecules/UiRating/UiRating.vue
@@ -36,7 +36,7 @@
           v-model="rate"
           v-bind="ratingItemAttrs(item)"
           :value="`${item.index}`"
-          :name="ratingName"
+          :input-attrs="{ name: ratingName }"
           class="ui-rating__option"
           @mouseover="hoverHandler($event, item.index)"
           @mouseleave="hoverHandler($event, item.index)"
@@ -288,6 +288,14 @@ const ratingItemAttrs = ({
       }
     }
 
+    @include mixins.with-focus {
+      &:focus-within {
+        #{$this}__radio {
+          box-shadow: var(--focus-outer);
+        }
+      }
+    }
+
     &:active {
       #{$this}__icon {
         --icon-color: #{functions.var($element + "-active-icon", color, var(--color-icon-secondary-active))};
@@ -311,6 +319,7 @@ const ratingItemAttrs = ({
     display: flex;
     align-items: center;
     justify-content: center;
+    border-radius: var(--border-radius-button);
 
     &--is-checked {
       #{$this}__icon {


### PR DESCRIPTION
# Related issue
Close #180 

# Scope of work
* show focus for tab navigation
* focus selected value (pass name in right way)

# Screenshots of visual changes
<img width="250" alt="Zrzut ekranu 2023-05-19 o 10 48 56" src="https://github.com/infermedica/component-library/assets/12138170/4b98bb80-3757-494b-91a2-ceedf8269402">

