### PR TITLE
fix: missing `tileItemAttrs` slot prop for `UiSimpleQuestion`

### DIFF
--- a/src/components/organisms/UiSimpleQuestion/UiSimpleQuestion.vue
+++ b/src/components/organisms/UiSimpleQuestion/UiSimpleQuestion.vue
@@ -14,7 +14,8 @@
           item,
           modelValue,
           isTileSmall,
-          updateHandler
+          updateHandler,
+          tileItemAttrs,
         }"
       >
         <UiTile


### PR DESCRIPTION
fix: define missing `tileItemAttrs` slot prop for `UiSimpleQuestion` component.