### PR TITLE
fix: missing name attribute for multiple choices item inputs

### DIFF
--- a/src/components/organisms/UiMultipleChoices/UiMultipleChoices.spec.js
+++ b/src/components/organisms/UiMultipleChoices/UiMultipleChoices.spec.js
@@ -82,4 +82,22 @@ describe('UiMultipleChoices.vue', () => {
     await wrapper.vm.$nextTick();
     expect(wrapper.emitted('update:invalid')).toBeTruthy();
   });
+
+  test('renders inputs with name attribute', () => {
+    const options = [ {
+      name: 'Yes',
+      value: 'yes',
+    } ];
+    const wrapper = mount(UiMultipleChoices, {
+      props: {
+        items: [ {
+          id: 'diabetes',
+          name: 'I have diabetes',
+        } ],
+        options,
+      },
+    });
+
+    expect(wrapper.find('input').attributes()).toContain({ name: 'diabetes' });
+  });
 });

--- a/src/components/organisms/UiMultipleChoices/_internal/UiMultipleChoicesItem.vue
+++ b/src/components/organisms/UiMultipleChoices/_internal/UiMultipleChoicesItem.vue
@@ -102,7 +102,6 @@
               v-model="value"
               v-bind="option"
               :tag="UiRadio"
-              :name="multipleChoicesItemId"
               :class="[
                 'ui-multiple-choices-item__option-content', {
                   'ui-radio--has-error': invalid,
@@ -284,7 +283,13 @@ const value = computed({
   },
 });
 const hasInfo = computed(() => (Object.keys(props.buttonInfoAttrs).length > 0));
-const optionsToRender = computed(() => props.options.map((option) => ({ ...option })));
+const optionsToRender = computed(() => props.options.map((option) => ({
+  ...option,
+  inputAttrs: {
+    name: multipleChoicesItemId.value,
+    ...option.inputAttrs,
+  },
+})));
 </script>
 
 <style lang="scss">


### PR DESCRIPTION
### Related issue
Closes #198 

### Scope of work
- Pass `name` attribute to `input-attrs` instead of radio wrapper

### Recording
https://github.com/infermedica/component-library/assets/17556031/550ccf84-ff76-464a-950f-9d2a9b1ddeb2

