### PR TITLE
fix: auto skip to next date field

### DIFF
--- a/src/components/organisms/UiDatepicker/UiDatepicker.spec.js
+++ b/src/components/organisms/UiDatepicker/UiDatepicker.spec.js
@@ -173,5 +173,20 @@ describe('UiDatepicker.vue', () => {
 
     expect(calendar.findComponent(UiPopover).exists()).toBe(false);
   });
+
+  test('skips to next field when entered value can\'t includes any other number', async () => {
+    const wrapper = mountDatepicker();
+
+    const dayInput = wrapper.findComponent(UiDatepickerDayInput).find('input');
+    const monthInput = wrapper.findComponent(UiDatepickerMonthInput).find('input');
+
+    dayInput.element.value = '4';
+    await dayInput.trigger('input', { data: '4' });
+
+    // we focus with 0ms delay, so, we also need to wait 0ms
+    await new Promise((resolve) => { setTimeout(resolve, 0); });
+
+    expect(document.activeElement).toBe(monthInput.element);
+  });
 });
 

--- a/src/components/organisms/UiDatepicker/_internal/UiDatepickerDayInput.vue
+++ b/src/components/organisms/UiDatepicker/_internal/UiDatepickerDayInput.vue
@@ -1,13 +1,13 @@
 <template>
   <UiInput
-    id="month"
+    id="day"
     ref="input"
-    v-model="day"
+    :model-value="day"
     :class="{ 'ui-input--has-error': hasError }"
     :placeholder="translation.placeholderDay"
     :input-attrs="defaultProps.inputAttrs"
     @blur="standardizeDayFormat"
-    @input="checkDay($event as InputEvent)"
+    @input="handleInput($event as InputEvent)"
     @keydown="numbersOnly"
   />
 </template>
@@ -81,12 +81,13 @@ const day = computed({
 });
 const validationError = computed(() => (day.value.length === 2 && !props.valid));
 const hasError = computed(() => (validationError.value || unfulfilledDayError.value || props.error));
-const checkDay = async (event: InputEvent) => {
+const handleInput = async (event: InputEvent) => {
   unfulfilledDayError.value = false;
   const {
     data, target,
   } = event;
   const { value } = target as HTMLInputElement;
+  day.value = value;
   await nextTick();
   if (data && (![
     '0',

--- a/src/components/organisms/UiDatepicker/_internal/UiDatepickerMonthInput.vue
+++ b/src/components/organisms/UiDatepicker/_internal/UiDatepickerMonthInput.vue
@@ -2,12 +2,12 @@
   <UiInput
     id="month"
     ref="input"
-    v-model="month"
+    :model-value="month"
     :class="{ 'ui-input--has-error': hasError }"
     :placeholder="translation.placeholderMonth"
     :input-attrs="defaultProps.inputAttrs"
     @blur="standardizeMonthFormat"
-    @input="checkMonth($event as InputEvent)"
+    @input="handleInput($event as InputEvent)"
     @keydown="numbersOnly"
   />
 </template>
@@ -81,12 +81,13 @@ const month = computed({
 });
 const validationError = computed(() => (month.value.length === 2 && !props.valid));
 const hasError = computed(() => (validationError.value || unfulfilledMonthError.value || props.error));
-const checkMonth = async (event: InputEvent) => {
+const handleInput = async (event: InputEvent) => {
   unfulfilledMonthError.value = false;
   const {
     data, target,
   } = event;
   const { value } = target as HTMLInputElement;
+  month.value = value;
   await nextTick();
   if (data && (![
     '0',

--- a/src/components/organisms/UiDatepicker/_internal/UiDatepickerYearInput.vue
+++ b/src/components/organisms/UiDatepicker/_internal/UiDatepickerYearInput.vue
@@ -2,12 +2,12 @@
   <UiInput
     id="year"
     ref="input"
-    v-model="year"
+    :model-value="year"
     :class="{ 'ui-input--has-error': hasError || error }"
     :placeholder="translation.placeholderYear"
     :input-attrs="defaultProps.inputAttrs"
     @blur="standardizeYearFormat"
-    @input="checkYear($event as InputEvent)"
+    @input="handleInput($event as InputEvent)"
     @keydown="numbersOnly"
   />
 </template>
@@ -81,12 +81,13 @@ const year = computed({
 });
 const validationError = computed(() => (year.value.length === 4 && !props.valid));
 const hasError = computed(() => (validationError.value || unfulfilledYearError.value || props.error));
-const checkYear = async (event: InputEvent) => {
+const handleInput = async (event: InputEvent) => {
   unfulfilledYearError.value = false;
   const {
     data, target,
   } = event;
   const { value } = target as HTMLInputElement;
+  year.value = value;
   await nextTick();
   if (data && value.length === 4 && props.valid) {
     emit('change-input', 'year');


### PR DESCRIPTION
### Related issue
Closes #201 

### Scope of work
- Handle update of input only by `@input` events instead of a combination of `@input` and `v-model` that cause incorrect order of value assignments

### Recording
https://github.com/infermedica/component-library/assets/17556031/d9bc8d37-275c-42f1-98de-d3878d35ef8f


