### PR TITLE
fix: incorrect position of underline element in UiTabs

### DIFF
--- a/src/components/organisms/UiTabs/UiTabs.vue
+++ b/src/components/organisms/UiTabs/UiTabs.vue
@@ -86,7 +86,7 @@ const containerY = ref(0);
 const containerH = ref(0);
 
 const offsetX = computed(() => {
-  Number(containerX.value * 0); /* Hack for keeping reactivity */
+  const hack = containerX.value * 0;
   if (!activeTabEl.value) return 0;
   const firstTab = tabs.value?.children[0].children[0];
   if (!firstTab) return 0;
@@ -94,15 +94,15 @@ const offsetX = computed(() => {
   const { x: activeX } = activeTabEl.value.getBoundingClientRect();
   const { x: firstX } = firstTab.getBoundingClientRect();
 
-  return activeX - firstX;
+  return activeX - firstX + hack;
 });
 
 const offsetY = computed(() => {
-  Number(containerH.value * 0); /* Hack for keeping reactivity */
+  const hack = containerH.value * 0;
 
   if (!activeTabEl.value) return 0;
   const { y } = activeTabEl.value.getBoundingClientRect();
-  return y - containerY.value;
+  return y - containerY.value + hack;
 });
 
 const scale = computed(() => {

--- a/src/components/organisms/UiTabs/UiTabs.vue
+++ b/src/components/organisms/UiTabs/UiTabs.vue
@@ -29,14 +29,16 @@ import {
   ref,
   computed,
   provide,
+  onMounted,
 } from 'vue';
 import type { CSSProperties } from 'vue';
 import UiTabsItem from './_internal/UiTabsItem.vue';
 import type { TabsItemAttrsProps } from './_internal/UiTabsItem.vue';
 import type { DefineAttrsProps } from '../../../types';
+import type { OrNull } from '../../../types/utils';
 
 export type TabsHandleTabActive = (name: string) => void;
-export type TabsSetActiveElement = (element: HTMLElement | null) => void;
+export type TabsSetActiveElement = (element: OrNull<HTMLElement>) => void;
 export interface TabsProps {
   /**
    * Use this props or v-model to set opened items.
@@ -75,32 +77,61 @@ const itemsToRender = computed<TabsProps['items']>(() => (props.items.map((item,
     name: name || `tabs-item-${key}`,
   };
 })));
-const tabs = ref<HTMLDivElement | null>(null);
-const activeTabHTMLElement = ref<HTMLElement | null>(null);
+
+const tabs = ref<OrNull<HTMLDivElement>>(null);
+const activeTabEl = ref<OrNull<HTMLElement>>(null);
+
+const containerX = ref(0);
+const containerY = ref(0);
+const containerH = ref(0);
+
 const offsetX = computed(() => {
-  if (activeTabHTMLElement.value === null) return 0;
+  Number(containerX.value * 0); /* Hack for keeping reactivity */
+  if (!activeTabEl.value) return 0;
   const firstTab = tabs.value?.children[0].children[0];
-  const activeTabRect = activeTabHTMLElement.value.getBoundingClientRect();
-  const tabsRect = tabs.value?.getBoundingClientRect();
   if (!firstTab) return 0;
-  if (tabsRect && Math.ceil((firstTab.getBoundingClientRect().right / tabsRect.right) * 100) > 50) {
-    return ((activeTabRect.x + activeTabRect.width) - firstTab.getBoundingClientRect().right);
-  }
-  return activeTabRect.x - firstTab.getBoundingClientRect().x;
+
+  const { x: activeX } = activeTabEl.value.getBoundingClientRect();
+  const { x: firstX } = firstTab.getBoundingClientRect();
+
+  return activeX - firstX;
 });
+
+const offsetY = computed(() => {
+  Number(containerH.value * 0); /* Hack for keeping reactivity */
+
+  if (!activeTabEl.value) return 0;
+  const { y } = activeTabEl.value.getBoundingClientRect();
+  return y - containerY.value;
+});
+
 const scale = computed(() => {
-  if (activeTabHTMLElement.value === null) return 1;
+  if (activeTabEl.value === null) return 1;
   const firstTabRect = tabs.value?.children[0].children[0].getBoundingClientRect();
   if (!firstTabRect) return 1;
-  const activeTabRect = activeTabHTMLElement.value.getBoundingClientRect();
+  const activeTabRect = activeTabEl.value.getBoundingClientRect();
   return activeTabRect.width / firstTabRect.width;
 });
+
+const containerObserver = new ResizeObserver(([ { target } ]) => {
+  const rect = target.getBoundingClientRect();
+
+  containerX.value = rect.width;
+  containerH.value = rect.height;
+  containerY.value = rect.y;
+});
+
+onMounted(() => {
+  if (tabs.value) containerObserver.observe(tabs.value);
+});
+
 const style = computed<CSSProperties>(() => ({
+  '--_tabs-indicator-offset-y': `${offsetY.value}px`,
   '--_tabs-indicator-offset-x': `${offsetX.value}px`,
   '--_tabs-indicator-scale-x': scale.value,
 }));
-const setActiveHTMLElement = (element: HTMLElement | null): void => {
-  activeTabHTMLElement.value = element;
+const setActiveHTMLElement = (element: OrNull<HTMLElement>): void => {
+  activeTabEl.value = element;
 };
 provide<TabsSetActiveElement>('setActiveHTMLElement', setActiveHTMLElement);
 const handleTabActive = (name: string) => {

--- a/src/components/organisms/UiTabs/UiTabs.vue
+++ b/src/components/organisms/UiTabs/UiTabs.vue
@@ -30,6 +30,7 @@ import {
   computed,
   provide,
   onMounted,
+  onUnmounted,
   reactive,
   watchEffect,
 } from 'vue';
@@ -101,6 +102,8 @@ const calculateOffset = () => {
   offsetY.value = activeRect.y - containerRect.y;
 };
 
+watchEffect(calculateOffset);
+
 const scale = computed(() => {
   if (activeTabEl.value === null) return 1;
   const firstTabRect = tabs.value?.children[0].children[0].getBoundingClientRect();
@@ -121,7 +124,9 @@ onMounted(() => {
   if (tabs.value) containerObserver.observe(tabs.value);
 });
 
-watchEffect(calculateOffset);
+onUnmounted(() => {
+  containerObserver.disconnect();
+});
 
 const style = computed<CSSProperties>(() => ({
   '--_tabs-indicator-offset-y': `${offsetY.value}px`,

--- a/src/components/organisms/UiTabs/_internal/UiTabsItem.vue
+++ b/src/components/organisms/UiTabs/_internal/UiTabsItem.vue
@@ -168,10 +168,6 @@ onMounted(() => {
         transform: translate3d(var(--_tabs-indicator-offset-x), var(--_tabs-indicator-offset-y), 0) scale3d(var(--_tabs-indicator-scale-x), 1, 1);
         transform-origin: left;
         transition: transform 150ms ease-in-out;
-
-        [dir="rtl"] & {
-          transform-origin: right;
-        }
       }
     }
 

--- a/src/components/organisms/UiTabs/_internal/UiTabsItem.vue
+++ b/src/components/organisms/UiTabs/_internal/UiTabsItem.vue
@@ -165,7 +165,7 @@ onMounted(() => {
         height: functions.var($element + "-indicator", height, 2px);
         background: functions.var($element + "-indicator", background, var(--color-border-selection));
         content: "";
-        transform: translate3d(var(--_tabs-indicator-offset-x), 0, 0) scale3d(var(--_tabs-indicator-scale-x), 1, 1);
+        transform: translate3d(var(--_tabs-indicator-offset-x), var(--_tabs-indicator-offset-y), 0) scale3d(var(--_tabs-indicator-scale-x), 1, 1);
         transform-origin: left;
         transition: transform 150ms ease-in-out;
 

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -1,0 +1,1 @@
+export type OrNull<T> = T | null


### PR DESCRIPTION
### Related issue
Closes #202 

### Scope of work
- **Added better RWD support** When resizing tabs component underline was not updated.
- **Added vertical tabs support**. When we had more then one row of tabs underline was not displayed correctly.
- **Fixed issue with incorrect underline position** Underline pseudo element was not displayed in the right place when the fist tab was not selected by default.

### video

https://github.com/infermedica/component-library/assets/89569524/9a324a51-3330-4ae4-8739-4a6737d3b447

@pspaczek 

