### PR TITLE
fix: keyboard navigation works incorrectly in sidepanel content

### DIFF
--- a/src/components/organisms/UiSidePanel/UiSidePanel.stories.js
+++ b/src/components/organisms/UiSidePanel/UiSidePanel.stories.js
@@ -803,7 +803,6 @@ export const WithContentSlot = {
     >
       <template #content="{ contentAttrs }">
         <div
-          v-scroll-tabindex
           v-keyboard-focus
           v-bind="contentAttrs"
           class="ui-side-panel__content"

--- a/src/components/organisms/UiSidePanel/UiSidePanel.vue
+++ b/src/components/organisms/UiSidePanel/UiSidePanel.vue
@@ -137,7 +137,6 @@
             v-bind="{ contentAttrs }"
           >
             <div
-              v-scroll-tabindex
               v-keyboard-focus
               class="ui-side-panel__content"
               v-bind="contentAttrs"
@@ -167,7 +166,6 @@ import type {
 import {
   focusTrap as vFocusTrap,
   bodyScrollLock as vBodyScrollLock,
-  scrollTabindex as vScrollTabindex,
   keyboardFocus as vKeyboardFocus,
 } from '../../../utilities/directives';
 import { focusElement } from '../../../utilities/helpers';


### PR DESCRIPTION
I would suggest removing scrollTabIndex directive as it only messes up focusing on elements inside SidePanel content. Scrolling with arrows up and down seems to be still possible without directive if we are focused inside side panel content.
With directive present scrolling with arrows up and down was also only possible if focus was inside SidePanel content.