### PR TITLE
fix: missing name attribute for inputs in UiScale

### DIFF
--- a/src/components/molecules/UiScale/UiScale.vue
+++ b/src/components/molecules/UiScale/UiScale.vue
@@ -29,7 +29,6 @@
           v-bind="item"
           v-model="scaleValue"
           :value="index"
-          :name="scaleName"
           class="ui-scale__option"
           :aria-labelledby="`scale-label-${index}`"
           @mouseover="hoverHandler($event, index)"
@@ -282,6 +281,10 @@ const itemsToRender = computed<RadioAttrsProps[]>(() => (Array.from({ length: ma
     textLabelAttrs: {
       tag: 'div',
       ...radioOptionAttrs?.textLabelAttrs,
+    },
+    inputAttrs: {
+      name: scaleName.value,
+      ...radioOptionAttrs?.inputAttrs,
     },
   };
 })));


### PR DESCRIPTION
### Related issue
Closes #208 

### Scope of work
- Pass `name` attribute to `input-attrs` instead of radio wrapper

### Recording


https://github.com/infermedica/component-library/assets/17556031/f8a7ff80-2b01-4deb-a675-2b82683f2807

