### PR TITLE
fix: keyboard navigation works incorrectly in UiSidePanel

### DIFF
--- a/src/components/organisms/UiSidePanel/UiSidePanel.vue
+++ b/src/components/organisms/UiSidePanel/UiSidePanel.vue
@@ -138,7 +138,6 @@
           >
             <div
               v-scroll-tabindex
-              v-keyboard-focus
               class="ui-side-panel__content"
               v-bind="contentAttrs"
             >


### PR DESCRIPTION
Close #200, #207

I removed `v-keyboard-focus` everything works fine. This action shouldn't change anything for focus visibility. 
Later I will check why `v-keyboard-focus` make this issue. 