### PR TITLE
fix: translations for UiRating component

### DIFF
--- a/src/components/molecules/UiRating/UiRating.spec.js
+++ b/src/components/molecules/UiRating/UiRating.spec.js
@@ -22,4 +22,16 @@ describe('UiRating.vue', () => {
     });
     expect(wrapper.findAll('.activeIcon').length).toBe(3);
   });
+  test('respects translation prop', () => {
+    const wrapper = mount(UiRating, {
+      props: {
+        max: '5',
+        modelValue: '3',
+        translation: { stars: (star) => `${star} custom stars` },
+      },
+    });
+
+    const [ firstOption ] = wrapper.findAll('.ui-rating__option');
+    expect(firstOption.text()).toBe('1 custom stars');
+  });
 });

--- a/src/components/molecules/UiRating/UiRating.vue
+++ b/src/components/molecules/UiRating/UiRating.vue
@@ -29,7 +29,7 @@
           hoverHandler,
           finalScore,
           settings,
-          translation: defaultProps.translation
+          translation
         }"
       >
         <UiRadio
@@ -93,7 +93,7 @@
             <span
               v-bind="textLabelAttrs"
               class="visual-hidden"
-            >{{ defaultProps.translation.stars(item.index) }}</span>
+            >{{ translation.stars(item.index) }}</span>
           </template>
         </UiRadio>
       </slot>
@@ -189,7 +189,6 @@ const defaultProps = computed(() => {
   const iconDefault: IconAttrsProps['icon'] = 'star-outlined';
   const iconActive: IconAttrsProps['icon'] = 'star-filled';
   return {
-    translation: { stars: (index: number) => (`${index} stars`) },
     settings: {
       iconDefault,
       iconActive,

--- a/src/components/molecules/UiRating/UiRating.vue
+++ b/src/components/molecules/UiRating/UiRating.vue
@@ -29,7 +29,7 @@
           hoverHandler,
           finalScore,
           settings,
-          translation
+          translation: defaultProps.translation
         }"
       >
         <UiRadio
@@ -93,7 +93,7 @@
             <span
               v-bind="textLabelAttrs"
               class="visual-hidden"
-            >{{ translation.stars(item.index) }}</span>
+            >{{ defaultProps.translation.stars(item.index) }}</span>
           </template>
         </UiRadio>
       </slot>
@@ -124,7 +124,7 @@ export interface RatingSettings {
   iconActive?: Icon;
 }
 export interface RatingTranslation {
-  stars: (index: number) => string;
+  stars?: (index: number) => string;
 }
 export interface RatingRenderItem extends RadioAttrsProps {
   index: number;
@@ -180,7 +180,7 @@ const props = withDefaults(defineProps<RatingProps>(), {
     iconDefault: 'star-outlined',
     iconActive: 'star-filled',
   }),
-  translation: () => ({ stars: (index: number) => (`${index} stars`) }),
+  translation: () => ({ }),
   tag: 'fieldset',
   legend: '',
   radioOptionAttrs: () => ({}),
@@ -189,6 +189,10 @@ const defaultProps = computed(() => {
   const iconDefault: IconAttrsProps['icon'] = 'star-outlined';
   const iconActive: IconAttrsProps['icon'] = 'star-filled';
   return {
+    translation: {
+      stars: (index: number) => (`${index} stars`),
+      ...props.translation,
+    },
     settings: {
       iconDefault,
       iconActive,


### PR DESCRIPTION
### Related issue
Closes #220 

### Scope of work
- Use translation from passed props instead of constant computed property


