### PR TITLE
fix: inactive Steps violate a11y Contrast rules

### DIFF
--- a/src/components/molecules/UiStepper/_internal/UiStepperStep.vue
+++ b/src/components/molecules/UiStepper/_internal/UiStepperStep.vue
@@ -14,7 +14,7 @@
     >
       <component
         v-bind="itemAttrs"
-        :is="itemTag"
+        :is="UiButton"
         :class="[
           'ui-stepper-step__content', itemClass
         ]"
@@ -44,8 +44,6 @@ import type {
 import useAttributes from '../../../../composable/useAttributes';
 import UiButton from '../../../atoms/UiButton/UiButton.vue';
 import type { ButtonAttrsProps } from '../../../atoms/UiButton/UiButton.vue';
-import UiText from '../../../atoms/UiText/UiText.vue';
-import type { TextAttrsProps } from '../../../atoms/UiText/UiText.vue';
 import UiListItem from '../../../organisms/UiList/_internal/UiListItem.vue';
 import type { DefineAttrsProps } from '../../../../types';
 
@@ -63,15 +61,18 @@ export interface StepperStepProps {
    */
   label?: string;
 }
-export type StepperStepAttrsProps = DefineAttrsProps<StepperStepProps, ButtonAttrsProps | TextAttrsProps>
+export type StepperStepAttrsProps = DefineAttrsProps<StepperStepProps, ButtonAttrsProps>
 
 const props = withDefaults(defineProps<StepperStepProps>(), {
   index: 0,
   activeStepIndex: 0,
   label: '',
 });
+
 const isCurrentStep = computed(() => props.index === props.activeStepIndex);
 const isVisitedStep = computed(() => props.index < props.activeStepIndex);
+const isInactiveStep = computed(() => props.index > props.activeStepIndex);
+
 const listItemAttrs = computed(() => ({
   class: [
     'ui-stepper-step',
@@ -81,27 +82,25 @@ const listItemAttrs = computed(() => ({
     },
   ],
 }));
-const itemTag = computed(() => (isVisitedStep.value
-  ? UiButton
-  : UiText));
-const itemClass = computed(() => (isVisitedStep.value
-  ? [
+const itemClass = computed(() => (
+  [
     'ui-button--text',
     'ui-button--theme-secondary',
+    isInactiveStep.value ? 'ui-button--is-disabled' : '',
   ]
-  : [ { 'ui-text--body-1-thick': isCurrentStep.value } ]
 ));
+
 const {
   attrs, listeners,
 } = useAttributes<ButtonHTMLAttributes | HTMLAttributes>();
-const itemAttrs = computed<ButtonAttrsProps | TextAttrsProps>(() => (isVisitedStep.value
+const itemAttrs = computed<ButtonAttrsProps>(() => (isVisitedStep.value
   ? {
     ...listeners.value,
     ...attrs.value,
   }
   : {
-    tag: 'span',
-    ...Object.keys(attrs.value).reduce((attributes: TextAttrsProps, attribute) => {
+    disabled: true,
+    ...Object.keys(attrs.value).reduce((attributes: ButtonAttrsProps, attribute) => {
       if (!attribute.match(/(to|href)/)) {
         attributes[attribute] = attrs.value[attribute]; // eslint-disable-line no-param-reassign
       }
@@ -150,6 +149,17 @@ const itemAttrs = computed<ButtonAttrsProps | TextAttrsProps>(() => (isVisitedSt
 
     #{$this}__content {
       --text-color: #{functions.var($element + "-content", color, revert)};
+    }
+  }
+
+  &--is-current {
+    --button-color: var(--color-text-body);
+    --button-hover-color: var(--color-text-body);
+    --button-active-color: var(--color-text-body);
+    --button-font: var(--font-body-1-thick);
+
+    #{$this}__content {
+      cursor: auto;
     }
   }
 

--- a/src/components/molecules/UiStepper/_internal/UiStepperStep.vue
+++ b/src/components/molecules/UiStepper/_internal/UiStepperStep.vue
@@ -156,6 +156,7 @@ const itemAttrs = computed<ButtonAttrsProps>(() => (isVisitedStep.value
     --button-hover-color: var(--color-text-body);
     --button-active-color: var(--color-text-body);
     --button-font: var(--font-body-1-thick);
+    --button-letter-spacing: var(--letter-spacing-body-1-thick)
 
     #{$this}__content {
       cursor: auto;

--- a/src/components/molecules/UiStepper/_internal/UiStepperStep.vue
+++ b/src/components/molecules/UiStepper/_internal/UiStepperStep.vue
@@ -12,9 +12,8 @@
         label,
       }"
     >
-      <component
+      <UiButton
         v-bind="itemAttrs"
-        :is="UiButton"
         :class="[
           'ui-stepper-step__content', itemClass
         ]"
@@ -26,7 +25,7 @@
         >
           {{ label }}
         </slot>
-      </component>
+      </UiButton>
     </slot>
   </UiListItem>
 </template>


### PR DESCRIPTION
Closes #222 

I decided to revert the change and have all steps become UiButtons. Not only it fixes the issue, but I think inactive buttons are overall more descriptive than switching between text and button element.