### PR TITLE
fix: improve tree shaking and reduce chunk sizes

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@infermedica/component-library",
   "description": "Vue 3 UI library for healthcare and not only.",
   "version": "0.7.1",
+  "sideEffects": ["*.vue"],
   "engines": {
     "node": ">=16.13.2",
     "pnpm": ">=6.32"


### PR DESCRIPTION
Chunks produced by Webpack and Vite for @infermedica/component-library are excessively large due to suboptimal tree shaking.

Configuring the `"sideEffects": ["*.vue"]` property in package.json results in a significant reduction in chunk size.

For clarity, I've set up two sandboxes to demonstrate the difference in chunk sizes before and after the proposed changes.
Execute the `pnpm build` command to generate the see output.

**Before changes**: https://stackblitz.com/edit/vitejs-vite-v6mkjt
```
dist/index.html                   0.45 kB │ gzip:  0.30 kB
dist/assets/index-9f343985.css  196.77 kB │ gzip: 21.06 kB
dist/assets/index-46952e10.js    57.29 kB │ gzip: 22.98 kB
```

**After changes**: https://stackblitz.com/edit/vitejs-vite-bdewkc
```
dist/index.html                  0.45 kB │ gzip:  0.30 kB
dist/assets/index-07e3b371.css  20.00 kB │ gzip:  3.37 kB
dist/assets/index-ba3e8a62.js   57.25 kB │ gzip: 22.94 kB
```