### PR TITLE
fix: adjust UiMenuItem to the newest MGP Component Library design:

### DIFF
--- a/src/components/organisms/UiMenu/_internal/UiMenuItem.vue
+++ b/src/components/organisms/UiMenu/_internal/UiMenuItem.vue
@@ -68,7 +68,7 @@ export interface MenuItemProps {
 export type MenuItemAttrsProps = DefineAttrsProps<MenuItemProps, ListItemAttrsProps>;
 
 const props = withDefaults(defineProps<MenuItemProps>(), {
-  icon: 'checkmark',
+  icon: 'present',
   suffixVisible: 'default',
   suffixAttrs: () => ({ class: 'ui-button--text ui-menu-item__suffix' }),
   listItemAttrs: () => ({ class: 'ui-menu-item' }),
@@ -109,7 +109,8 @@ const defaultProps = computed(() => ({
 
     --button-font: #{functions.var($element + "-button", font, var(--font-body-1))};
     --button-letter-spacing: #{functions.var($element + "-button", letter-spacing, var(--letter-spacing-body-1))};
-
+    --border-radius-button: var(--border-radius-form);
+    
     justify-content: space-between;
   }
 

--- a/src/components/organisms/UiMenu/_internal/UiMenuItem.vue
+++ b/src/components/organisms/UiMenu/_internal/UiMenuItem.vue
@@ -106,11 +106,11 @@ const defaultProps = computed(() => ({
     @include mixins.override-logical(list-item-tablet-content, $element + "-button", padding, var(--space-8));
     @include mixins.override-logical(button, $element + "-button", padding, var(--space-8));
     @include mixins.override-logical(button, $element + "-button", border-width, 0);
+    @include mixins.override-logical(button, $element + "-button", border-radius, var(--border-radius-form));
 
     --button-font: #{functions.var($element + "-button", font, var(--font-body-1))};
     --button-letter-spacing: #{functions.var($element + "-button", letter-spacing, var(--letter-spacing-body-1))};
-    --border-radius-button: var(--border-radius-form);
-    
+
     justify-content: space-between;
   }
 

--- a/src/components/organisms/UiMenu/_internal/UiMenuItemSuffix.vue
+++ b/src/components/organisms/UiMenu/_internal/UiMenuItemSuffix.vue
@@ -50,7 +50,7 @@ export type MenuItemSuffixAttrsProps = DefineAttrsProps<MenuItemSuffixProps>;
 
 const props = withDefaults(defineProps<MenuItemSuffixProps>(), {
   label: '',
-  icon: 'checkmark',
+  icon: 'present',
   iconSuffixAttrs: () => ({}),
 });
 const defaultProps = computed(() => ({


### PR DESCRIPTION
- change `ui-menu-item__button`'s `border-radius` according to the design;
- change default icon to smaller one - from `checkmark` to `present`

[Link to the newest MGP Component Library](https://www.figma.com/file/2p8nMM7W88FU6r0kA52fAA/MGP-Component-Library?type=design&node-id=3-12660&mode=design&t=AUQplhjDmsNUAgLb-4)