### PR TITLE
feat: remove `exports` from package.json

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -7,6 +7,9 @@ export * from './src/types';
 export * from './src/utilities/helpers';
 export * from './src/utilities/directives';
 
+// composables
+export * from './src/composable';
+
 // component types
 export * from './src/components/atoms/UiBackdrop/UiBackdrop.vue';
 export * from './src/components/atoms/UiButton/UiButton.vue';

--- a/index.ts
+++ b/index.ts
@@ -3,6 +3,10 @@
 // types
 export * from './src/types';
 
+// utilities
+export * from './src/utilities/helpers';
+export * from './src/utilities/directives';
+
 // component types
 export * from './src/components/atoms/UiBackdrop/UiBackdrop.vue';
 export * from './src/components/atoms/UiButton/UiButton.vue';

--- a/package.json
+++ b/package.json
@@ -37,23 +37,6 @@
   },
   "main": "index.ts",
   "module": "index.ts",
-  "exports": {
-    ".": "./index.ts",
-    "./src/": "./src/",
-    "./styles/": "./src/styles/",
-    "./breakpoints": "./src/styles/exports/breakpoints.module.scss",
-    "./mixins/": "./src/styles/mixins",
-    "./transitions/": "./src/styles/transitions",
-    "./atoms/": "./src/components/atoms/",
-    "./molecules/": "./src/components/molecules/",
-    "./organisms/": "./src/components/organisms/",
-    "./templates/": "./src/components/templates/",
-    "./directives/": "./src/utilities/directives/",
-    "./transition/": "./src/utilities/transitions/",
-    "./helpers/": "./src/utilities/helpers/",
-    "./composable/": "./src/composable/",
-    "./icons/": "./src/assets/icons/"
-  },
   "files": [
     "src/*",
     "index.ts",

--- a/scripts/create-index.mjs
+++ b/scripts/create-index.mjs
@@ -24,6 +24,9 @@ function generateContent() {
   const contentIndexTs = `// Auto-generated file by create-index.js. Do not edit manually\n
 // types
 export * from './src/types';\n
+// utilities
+export * from './src/utilities/helpers';
+export * from './src/utilities/directives';\n
 // component types
 ${componentTypeLines.join('\n')}\n
 // components

--- a/scripts/create-index.mjs
+++ b/scripts/create-index.mjs
@@ -27,6 +27,8 @@ export * from './src/types';\n
 // utilities
 export * from './src/utilities/helpers';
 export * from './src/utilities/directives';\n
+// composables
+export * from './src/composable';\n
 // component types
 ${componentTypeLines.join('\n')}\n
 // components

--- a/src/composable/index.ts
+++ b/src/composable/index.ts
@@ -1,0 +1,5 @@
+export { default as useActiveElement } from './useActiveElement';
+export { default as useAttributes } from './useAttributes';
+export { default as useKeyValidation } from './useKeyValidation';
+export { default as useLink } from './useLink';
+export { default as useMutationObserver } from './useMutationObserver';


### PR DESCRIPTION
### Overview
This pull request removes the `exports` field from the `package.json` file to ensure compatibility with Vite, which currently does not support this feature. Additionally, the PR refactors the export structure in `index.ts` and adds a new index file for composables.

### Changes
- Removed `exports` section from `package.json`.
- Added new exports in `index.ts` for utilities, composables, and component types.
- Modified `scripts/create-index.mjs` to reflect the new export structure.
- Added a new `src/composable/index.ts` file for exporting composable utilities.
