### PR TITLE
fix: loaded content with redundant box

### DIFF
--- a/src/components/molecules/UiLoader/UiLoader.vue
+++ b/src/components/molecules/UiLoader/UiLoader.vue
@@ -132,5 +132,9 @@ const transitionComponentAttrs = computed<LoaderProps['transitionAttrs']>(() => 
   display: flex;
   align-items: center;
   justify-content: center;
+
+  &__loaded {
+    display: contents;
+  }
 }
 </style>

--- a/src/components/molecules/UiLoader/_internal/UiLoaderNativeTransition.vue
+++ b/src/components/molecules/UiLoader/_internal/UiLoaderNativeTransition.vue
@@ -4,7 +4,10 @@
       v-if="isLoading"
       name="loader"
     />
-    <div v-else>
+    <div
+      v-else
+      class="ui-loader__loaded"
+    >
       <slot />
     </div>
   </transition>

--- a/src/components/molecules/UiLoader/_internal/UiLoaderTransition.vue
+++ b/src/components/molecules/UiLoader/_internal/UiLoaderTransition.vue
@@ -8,6 +8,7 @@
   <div
     ref="contentEl"
     :style="contentStyle"
+    class="ui-loader__loaded"
   >
     <slot />
   </div>


### PR DESCRIPTION
In both cases, we need this `<div/>` to use `<transition/>` because IMO `<transition-group>` is used to other issues than UiLoader. To prevent problems with box model we want to use display: contents to make this div `invisible`.  
After:
![Zrzut ekranu 2023-09-4 o 11 09 49](https://github.com/infermedica/component-library/assets/12138170/0a9ff443-4d54-4aa4-a3f2-d51de3132cb9)

Before:
![Zrzut ekranu 2023-09-4 o 11 09 59](https://github.com/infermedica/component-library/assets/12138170/d60be6a9-4478-4ea0-92ed-b2108d3feef7)
