### PR TITLE
fix: TypeScript error in UiButton regarding loaderAttrs.type property

### DIFF
--- a/src/components/atoms/UiButton/UiButton.vue
+++ b/src/components/atoms/UiButton/UiButton.vue
@@ -65,7 +65,7 @@ const props = withDefaults(defineProps<ButtonProps>(), {
 });
 const defaultProps = computed(() => ({
   loaderAttrs: {
-    type: 'ellipsis',
+    type: 'ellipsis' as const,
     'transition-type': 'opacity',
     ...props.loaderAttrs,
   },


### PR DESCRIPTION
**BEFORE:**
<img width="961" alt="Zrzut ekranu 2023-09-14 o 10 27 54" src="https://github.com/infermedica/component-library/assets/13744352/208cfdfc-f688-43b3-a591-0d1fbf2796f4">

**AFTER:**
<img width="962" alt="image" src="https://github.com/infermedica/component-library/assets/13744352/178f2ddd-d128-4aea-8f53-9b8e86c1e428">
