### PR TITLE
feat: add character counter to UiFormField

### DIFF
--- a/src/components/molecules/UiFormField/UiFormField.mdx
+++ b/src/components/molecules/UiFormField/UiFormField.mdx
@@ -6,10 +6,13 @@ import scss from './UiFormField.stories.scss?raw';
 <Meta of={stories}/>
 
 # UiFormField
-<Canvas of={stories.WithInput} />
-<Controls of={stories.WithInput}/>
+<Canvas of={stories.WithTextarea} />
+<Controls of={stories.WithTextarea}/>
 
 ## Stories
+## With Input
+<Canvas of={stories.WithInput} />
+
 ### With Checkboxes
 <Canvas of={stories.WithCheckboxes}/>
 

--- a/src/components/molecules/UiFormField/UiFormField.stories.js
+++ b/src/components/molecules/UiFormField/UiFormField.stories.js
@@ -1,6 +1,8 @@
+import { ref } from 'vue';
 import UiFormField from '@/components/molecules/UiFormField/UiFormField.vue';
 import UiCheckbox from '@/components/atoms/UiCheckbox/UiCheckbox.vue';
 import UiInput from '@/components/atoms/UiInput/UiInput.vue';
+import UiTextarea from '@/components/atoms/UiTextarea/UiTextarea.vue';
 import UiText from '@/components/atoms/UiText/UiText.vue';
 import UiAlert from '@/components/molecules/UiAlert/UiAlert.vue';
 import './UiFormField.stories.scss';
@@ -63,6 +65,64 @@ export default {
         'var(--form-field-alert-margin-inline-start, 0) var(--form-field-alert-margin-inline-end, 0)',
     },
   },
+};
+
+export const WithTextarea = {
+  render: (args) => ({
+    components: {
+      UiFormField,
+      UiTextarea,
+    },
+    setup() {
+      const value = ref(args.text);
+      const errorMsg = ref(args.errorMessage);
+      const handleErrorEmit = (error) => {
+        if (error === 'max length exceeds') {
+          errorMsg.value = `Use max ${args.characterCounterAttrs?.max || 200} characters`;
+          return;
+        }
+        errorMsg.value = '';
+      };
+      return {
+        ...args,
+        value,
+        errorMsg,
+        handleErrorEmit,
+      };
+    },
+    template: `<UiFormField
+      :message="message"
+      :id="id"
+      :hint="hint"
+      :value="value"
+      :error-message="errorMsg"
+      :has-character-counter="hasCharacterCounter"
+      :text-message-attrs="textMessageAttrs"
+      :text-hint-attrs="textHintAttrs"
+      :alert-attrs="alertAttrs"
+      @error="handleErrorEmit"
+      class="form-field-with-input"
+    >
+      <template #default="{ id }">
+        <UiTextarea
+          v-model="value"
+          :id="id"
+          :class="[
+            'form-field-with-input__input',
+            { 'ui-textarea--has-error': errorMsg },
+          ]"
+        />
+      </template>
+    </UiFormField>`,
+  }),
+};
+WithTextarea.args = {
+  message: 'Message',
+  hint: 'Optional',
+  text: "Dear Doctor, I've been experiencing regular headaches for the last few weeks. The pain typically starts at the back of my head and travels to the front, settling behind my eyes. It's a steady, dull ache that doesn't respond to over-the-counter pain relief. There's a constant throbbing sensation, and sometimes it's accompanied by nausea. Bright lights and loud noises seem to make it worse. It's affecting my day-to-day activities. Please advise.",
+  hasCharacterCounter: true,
+  errorMessage: '',
+  characterCounterAttrs: { max: 400 },
 };
 
 export const WithInput = {

--- a/src/components/molecules/UiFormField/UiFormField.vue
+++ b/src/components/molecules/UiFormField/UiFormField.vue
@@ -57,29 +57,49 @@
     <slot
       v-bind="{ id: inputId }"
     />
-    <!-- @slot Use this slot to replace alert template. -->
-    <slot
-      name="alert"
-      v-bind="{
-        alertAttrs,
-        hasErrorMessage,
-        errorMessage,
-      }"
-    >
-      <UiAlert
-        v-if="hasErrorMessage"
-        v-bind="alertAttrs"
-        class="ui-form-field__alert"
+    <div class="ui-form-field__messages">
+      <!-- @slot Use this slot to replace alert template. -->
+      <slot
+        name="alert"
+        v-bind="{
+          alertAttrs,
+          hasErrorMessage,
+          errorMessage,
+        }"
       >
-        {{ errorMessage }}
-      </UiAlert>
-    </slot>
+        <UiAlert
+          v-if="hasErrorMessage"
+          v-bind="alertAttrs"
+          class="ui-form-field__alert"
+        >
+          {{ errorMessage }}
+        </UiAlert>
+      </slot>
+      <slot
+        name="character-counter"
+        v-bind="{
+          value,
+          characterCounterAttrs,
+          hasCharacterCounter,
+          handleErrorEmit,
+        }"
+      >
+        <UiFormFieldCharacterCounter
+          v-if="hasCharacterCounter"
+          v-bind="characterCounterAttrs"
+          :value="value"
+          @error="handleErrorEmit"
+        />
+      </slot>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { uid } from 'uid/single';
 import { computed } from 'vue';
+import UiFormFieldCharacterCounter from './_internal/UiFormFieldCharacterCounter.vue';
+import type { FormFieldCharacterCounterProps } from './_internal/UiFormFieldCharacterCounter.vue';
 import UiAlert from '../UiAlert/UiAlert.vue';
 import type { AlertAttrsProps } from '../UiAlert/UiAlert.vue';
 import UiText from '../../atoms/UiText/UiText.vue';
@@ -101,6 +121,14 @@ export interface FormFieldProps {
    */
   hint?: boolean | string;
   /**
+   * Use this props to pass value of input.
+   */
+  value?: string;
+  /**
+   * Use this props to show character counter.
+   */
+  hasCharacterCounter?: boolean;
+  /**
    * Use this props to set alert message
    */
   errorMessage?: boolean | string;
@@ -116,14 +144,20 @@ export interface FormFieldProps {
    * Use this props to pass attrs to UiAlert.
    */
   alertAttrs?: AlertAttrsProps;
+  characterCounterAttrs?: FormFieldCharacterCounterProps;
 }
 export type FormFieldAttrsProps = DefineAttrsProps<FormFieldProps>;
+export interface FormFieldEmits {
+  (e: 'error', value: string | null): void;
+}
+const emit = defineEmits<FormFieldEmits>();
 
 const props = withDefaults(defineProps<FormFieldProps>(), {
   message: false,
   id: '',
   hint: false,
   errorMessage: false,
+  hasCharacterCounter: false,
   textMessageAttrs: () => ({ tag: 'span' }),
   textHintAttrs: () => ({ tag: 'span' }),
   alertAttrs: () => ({}),
@@ -139,6 +173,10 @@ const defaultProps = computed(() => {
       tag,
       ...props.textHintAttrs,
     },
+    characterCounterAttrs: {
+      max: 240,
+      ...props.characterCounterAttrs,
+    },
   };
 });
 const inputId = computed(() => (
@@ -146,6 +184,9 @@ const inputId = computed(() => (
 ));
 const hasHint = computed(() => typeof props.hint !== 'boolean');
 const hasErrorMessage = computed(() => typeof props.errorMessage !== 'boolean');
+const handleErrorEmit = (error: string | null) => {
+  emit('error', error);
+};
 </script>
 
 <style lang="scss">
@@ -155,17 +196,30 @@ const hasErrorMessage = computed(() => typeof props.errorMessage !== 'boolean');
 .ui-form-field {
   $element: form-field;
 
-  &__label {
-    @include mixins.use-logical($element + "-alert", margin, 0 0 var(--space-8) 0);
+  display: flex;
+  flex-direction: column;
+  gap: functions.var($element, gap, var(--space-8));
 
+  &__label {
     display: flex;
     align-items: center;
     justify-content: flex-start;
-    gap: functions.var($element + "label", gap, var(--space-8));
+    gap: functions.var($element + "-label", gap, var(--space-8));
   }
 
-  &__alert {
-    @include mixins.use-logical($element + "-alert", margin, var(--space-8) 0 0 0);
+  &__messages {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--space-8);
+  }
+
+  &__character-counter {
+    margin-inline: auto 0;
+  }
+
+  &--is-disabled {
+    --text-color: var(--color-text-disabled);
   }
 }
 </style>

--- a/src/components/molecules/UiFormField/_internal/UiFormFieldCharacterCounter.vue
+++ b/src/components/molecules/UiFormField/_internal/UiFormFieldCharacterCounter.vue
@@ -1,0 +1,49 @@
+<template>
+  <UiText
+    class="ui-text--body-2-comfortable ui-text--theme-secondary ui-form-field__character-counter"
+  >
+    {{ length }}/{{ max }}
+  </UiText>
+</template>
+
+<script setup lang="ts">
+import {
+  computed,
+  watch,
+} from 'vue';
+import UiText from '../../../atoms/UiText/UiText.vue';
+import type { DefineAttrsProps } from '../../../../types/attrs';
+
+export interface FormFieldCharacterCounterProps {
+  /**
+   * Use this props to pass value of input.
+   */
+  value?: string;
+  /**
+   * Use this props to set max of characters.
+   */
+  max?: number;
+}
+export type FormFieldCharacterCounterAttrsProps = DefineAttrsProps<FormFieldCharacterCounterProps>
+export interface FormFieldCharacterCounterEmits {
+  (e: 'error', value: string | null): void;
+}
+
+const props = withDefaults(defineProps<FormFieldCharacterCounterProps>(), {
+  value: '',
+  max: 240,
+});
+const length = computed(() => (props.value.length));
+const emit = defineEmits<FormFieldCharacterCounterEmits>();
+watch(
+  length,
+  (size) => {
+    if (size > props.max) {
+      emit('error', 'max length exceeds');
+      return;
+    }
+    emit('error', null);
+  },
+  { immediate: true },
+);
+</script>


### PR DESCRIPTION
UiFormField allows to display character counter. 
UiFormField has new props:
* value
* hasCharacterCounter
* characterCounterAttrs
UiFormField has a new emit:
* error: string | null
![Kapture 2023-09-19 at 13 34 28](https://github.com/infermedica/component-library/assets/12138170/62cc17aa-c30a-443b-beca-04b2b000eab8)

How to handle error
```
 const handleErrorEmit = (error) => {
        if (error === 'max length exceeds') {
          errorMsg.value = 'Use max 240 characters';
          return;
        }
        errorMsg.value = '';
      };
```
