### PR TITLE
Fix: UiCard won't change icon unleass iconTriageAttrs are provided.

### DIFF
--- a/src/components/organisms/UiCard/UiCard.vue
+++ b/src/components/organisms/UiCard/UiCard.vue
@@ -145,7 +145,7 @@ const props = withDefaults(defineProps<CardProps>(), {
   subtitle: '',
   description: '',
   type: 'emergency_ambulance',
-  iconTriageAttrs: () => ({ icon: 'emergency-ambulance' }),
+  iconTriageAttrs: () => ({}),
   textSubtitleAttrs: () => ({}),
   headingTitleAttrs: () => ({}),
   textDescriptionAttrs: () => ({}),


### PR DESCRIPTION
Ui-icon is always set to emergency unless we provide the iconTriageAttrs. Deleted the default value for this prop.