### PR TITLE
fix: incorrect text alignment in dropdown item

### DIFF
--- a/src/components/molecules/UiDropdown/_internal/UiDropdownItem.vue
+++ b/src/components/molecules/UiDropdown/_internal/UiDropdownItem.vue
@@ -119,6 +119,7 @@ const buttonItemAttrs = computed<ButtonAttrsProps>(() => ({
   @include mixins.use-logical($element, margin, var(--space-8) 0 0);
 
   justify-content: space-between;
+  text-align: start;
 
   &:first-of-type {
     @include mixins.use-logical($element, margin, 0);


### PR DESCRIPTION
### Description
This PR addresses an alignment issue in the dropdown items. When the text spans more than two lines, the alignment was previously incorrect.

### Changes
Applied text-align: start to ensure consistent and correct alignment for multiline text.

### Screenshots

Before:
<img width="280" alt="Screenshot 2023-09-20 at 14 36 22" src="https://github.com/infermedica/component-library/assets/17556031/d9a36627-21a1-43bd-ab72-10c26d7bd4a3">

After:
<img width="280" alt="Screenshot 2023-09-20 at 14 37 31" src="https://github.com/infermedica/component-library/assets/17556031/b3dc3327-16b9-466e-9cd3-6aa49a441c12">
