### PR TITLE
fix: change padding in UiStepperStep according to the newest design

### DIFF
--- a/src/components/molecules/UiStepper/_internal/UiStepperStep.vue
+++ b/src/components/molecules/UiStepper/_internal/UiStepperStep.vue
@@ -116,7 +116,7 @@ const itemAttrs = computed<ButtonAttrsProps>(() => (isVisitedStep.value
   $element: stepper-step;
 
   --_stepper-step-indicator-width: #{functions.var($element + "-step-indicator", width, 4px)};
-  --_list-item-content-padding-block: #{functions.var($element + "-button", padding-block, var(--space-10))};
+  --_list-item-content-padding-block: #{functions.var($element + "-button", padding-block, var(--space-12))};
   --_list-item-content-padding-inline: #{functions.var($element + "-button", padding-inline, 0 var(--space-8))};
   --list-item-content-padding-block: var(--_list-item-content-padding-block);
   --list-item-content-padding-inline: var(--_list-item-content-padding-inline);


### PR DESCRIPTION
UiStepperStep padding got changed to `--space-12`. Token `--space-10` will be not used in designs.

<img width="751" alt="image" src="https://github.com/infermedica/component-library/assets/20798383/133f00f3-8867-40ff-9e55-3580db4dc7cc">
