### PR TITLE
fix(a11y): tiles as radios in UiSImpleQuestion component

### DIFF
--- a/src/components/atoms/UiButton/UiButton.vue
+++ b/src/components/atoms/UiButton/UiButton.vue
@@ -4,6 +4,7 @@
     v-keyboard-focus
     v-bind="routeAttrs"
     class="ui-button"
+    :type="tag === 'button' ? 'button' : null"
     :aria-disabled="isLoading ? true : null"
   >
     <UiLoader

--- a/src/components/molecules/UiTile/UiTile.stories.js
+++ b/src/components/molecules/UiTile/UiTile.stories.js
@@ -176,7 +176,8 @@ export const AsGroup = {
         modelValue,
       };
     },
-    template: `<div class="tile-as-group">
+    template: `<div class="tile-as-group" role="group" aria-labelledby="group-description">
+      <span id="group-description" class="visual-hidden" aria-hidden="true">Answers</span>
       <template
         v-for="(item, index) in items"
         :key="index"

--- a/src/components/molecules/UiTile/UiTile.stories.js
+++ b/src/components/molecules/UiTile/UiTile.stories.js
@@ -176,8 +176,16 @@ export const AsGroup = {
         modelValue,
       };
     },
-    template: `<div class="tile-as-group" role="group" aria-labelledby="group-description">
-      <span id="group-description" class="visual-hidden" aria-hidden="true">Answers</span>
+    template: `<div 
+      role="group" 
+      aria-labelledby="tile-as-group"
+      class="tile-as-group"
+    >
+      <span 
+        id="tile-as-group"
+        :aria-hidden="true"
+        class="visual-hidden"
+      >Answers</span>
       <template
         v-for="(item, index) in items"
         :key="index"

--- a/src/components/molecules/UiTile/UiTile.vue
+++ b/src/components/molecules/UiTile/UiTile.vue
@@ -2,10 +2,8 @@
   <UiButton
     :id="tileId"
     :class="[
-      'ui-button--outlined ui-tile',{ 'ui-tile--is-checked': isChecked }
+      'ui-button--outlined ui-tile', { 'ui-tile--is-checked': isChecked },
     ]"
-    role="radio"
-    :aria-checked="`${isChecked}`"
     @click="selectHandler"
   >
     <!-- @slot Use this slot to replace icon template. -->

--- a/src/components/molecules/UiTile/UiTile.vue
+++ b/src/components/molecules/UiTile/UiTile.vue
@@ -2,7 +2,8 @@
   <UiButton
     :id="tileId"
     :class="[
-      'ui-button--outlined ui-tile', { 'ui-tile--is-checked': isChecked },
+      'ui-button--outlined ui-tile',
+      { 'ui-tile--is-checked': isChecked },
     ]"
     @click="selectHandler"
   >

--- a/src/components/organisms/UiSimpleQuestion/UiSimpleQuestion.stories.js
+++ b/src/components/organisms/UiSimpleQuestion/UiSimpleQuestion.stories.js
@@ -128,3 +128,27 @@ export const WithTileSlot = {
     </UiSimpleQuestion>`,
   }),
 };
+
+export const WithGroupDescriptionSlot = {
+  render: (args) => ({
+    components: { UiSimpleQuestion },
+    setup() {
+      const modelValue = ref(args.initModelValue);
+      const legend = 'Default group description';
+      return {
+        ...args,
+        modelValue,
+        legend,
+      };
+    },
+    template: `<UiSimpleQuestion
+      v-model="modelValue"
+      :items="items"
+      :class="modifiers"
+      :legend="legend"
+    />
+    `,
+  }),
+
+  args: { modifiers: [ 'ui-simple-question--small' ] },
+};

--- a/src/components/organisms/UiSimpleQuestion/UiSimpleQuestion.vue
+++ b/src/components/organisms/UiSimpleQuestion/UiSimpleQuestion.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="ui-simple-question"
-    role="radiogroup"
+    role="group"
   >
     <template
       v-for="(item, index) in itemsToRender"
@@ -23,6 +23,7 @@
           :model-value="modelValue"
           :class="{ 'ui-tile--small': isTileSmall }"
           class="ui-simple-question__item"
+          type="submit"
           @update:model-value="updateHandler(item.value)"
         >
           {{ item.label }}

--- a/src/components/organisms/UiSimpleQuestion/UiSimpleQuestion.vue
+++ b/src/components/organisms/UiSimpleQuestion/UiSimpleQuestion.vue
@@ -2,7 +2,23 @@
   <div
     class="ui-simple-question"
     role="group"
+    aria-labelledby="ssn1"
   >
+    <slot
+      name="legend"
+      v-bind="{
+        legend,
+        id,
+      }"
+    >
+      <span
+        :id="id"
+        class="visual-hidden"
+        :aria-hidden="true"
+      >
+        {{ legend }}
+      </span>
+    </slot>
     <template
       v-for="(item, index) in itemsToRender"
       :key="index"
@@ -57,12 +73,12 @@ export interface SimpleQuestionProps {
    * Use this props to pass items for question
    */
   items?: SimpleQuestionItem[];
+  legend?: string
 }
 export type SimpleQuestionAttrsProps = DefineAttrsProps<SimpleQuestionProps>;
 export interface SimpleQuestionEmits {
   (e: 'update:modelValue', value: SimpleQuestionProps['modelValue']): void;
 }
-
 const props = withDefaults(defineProps<SimpleQuestionProps>(), {
   /**
    * Use this props or v-model to set value.
@@ -72,10 +88,11 @@ const props = withDefaults(defineProps<SimpleQuestionProps>(), {
    * Use this props to pass items for question
    */
   items: () => ([]),
+  legend: '',
 });
 const emit = defineEmits<SimpleQuestionEmits>();
-
 const attrs: SimpleQuestionAttrsProps = useAttrs();
+const id = 'ssn1';
 const isTileSmall = computed(() => attrs.class && attrs.class.includes('ui-simple-question--small'));
 const updateHandler = (value: SimpleQuestionProps['modelValue']) => {
   emit('update:modelValue', value);

--- a/src/components/organisms/UiSimpleQuestion/UiSimpleQuestion.vue
+++ b/src/components/organisms/UiSimpleQuestion/UiSimpleQuestion.vue
@@ -2,7 +2,7 @@
   <div
     class="ui-simple-question"
     role="group"
-    aria-labelledby="ssn1"
+    :aria-labelledby="id"
   >
     <slot
       name="legend"
@@ -12,9 +12,10 @@
       }"
     >
       <span
+        v-if="legend"
         :id="id"
-        class="visual-hidden"
         :aria-hidden="true"
+        class="visual-hidden"
       >
         {{ legend }}
       </span>
@@ -37,8 +38,10 @@
         <UiTile
           v-bind="tileItemAttrs(item)"
           :model-value="modelValue"
-          :class="{ 'ui-tile--small': isTileSmall }"
-          class="ui-simple-question__item"
+          :class="[
+            'ui-simple-question__item',
+            { 'ui-tile--small': isTileSmall }
+          ]"
           type="submit"
           @update:model-value="updateHandler(item.value)"
         >
@@ -54,6 +57,7 @@ import {
   computed,
   useAttrs,
 } from 'vue';
+import { uid } from 'uid/single';
 import UiTile from '../../molecules/UiTile/UiTile.vue';
 import type {
   TileModelValue,
@@ -73,6 +77,9 @@ export interface SimpleQuestionProps {
    * Use this props to pass items for question
    */
   items?: SimpleQuestionItem[];
+  /**
+   * Use this props to set legend.
+   */
   legend?: string
 }
 export type SimpleQuestionAttrsProps = DefineAttrsProps<SimpleQuestionProps>;
@@ -80,19 +87,13 @@ export interface SimpleQuestionEmits {
   (e: 'update:modelValue', value: SimpleQuestionProps['modelValue']): void;
 }
 const props = withDefaults(defineProps<SimpleQuestionProps>(), {
-  /**
-   * Use this props or v-model to set value.
-   */
   modelValue: () => ({}),
-  /**
-   * Use this props to pass items for question
-   */
   items: () => ([]),
   legend: '',
 });
 const emit = defineEmits<SimpleQuestionEmits>();
 const attrs: SimpleQuestionAttrsProps = useAttrs();
-const id = 'ssn1';
+const id = `simple-question-${uid()}`;
 const isTileSmall = computed(() => attrs.class && attrs.class.includes('ui-simple-question--small'));
 const updateHandler = (value: SimpleQuestionProps['modelValue']) => {
   emit('update:modelValue', value);

--- a/src/components/templates/UiQuestion/UiQuestion.stories.js
+++ b/src/components/templates/UiQuestion/UiQuestion.stories.js
@@ -275,7 +275,6 @@ export const WithoutSkipThisQuestion = {
 export const AsSimpleQuestion = {
   render: (args) => ({
     components: {
-      UiHeading,
       UiQuestion,
       UiSimpleQuestion,
     },
@@ -297,13 +296,10 @@ export const AsSimpleQuestion = {
       :button-issue-attrs="buttonIssueAttrs"
       :notification-feedback-attrs="notificationFeedbackAttrs"
     >
-    <template #title>
-      <UiHeading id="question-heading">{{ title }}</UiHeading>
-    </template>
       <UiSimpleQuestion
         v-model="modelValue"
         :items="items"
-        aria-labelledby="question-heading"
+        :legend="title"
       />
     </UiQuestion>`,
   }),

--- a/src/components/templates/UiQuestion/UiQuestion.stories.js
+++ b/src/components/templates/UiQuestion/UiQuestion.stories.js
@@ -275,6 +275,7 @@ export const WithoutSkipThisQuestion = {
 export const AsSimpleQuestion = {
   render: (args) => ({
     components: {
+      UiHeading,
       UiQuestion,
       UiSimpleQuestion,
     },
@@ -296,9 +297,13 @@ export const AsSimpleQuestion = {
       :button-issue-attrs="buttonIssueAttrs"
       :notification-feedback-attrs="notificationFeedbackAttrs"
     >
+    <template #title>
+      <UiHeading id="question-heading">{{ title }}</UiHeading>
+    </template>
       <UiSimpleQuestion
         v-model="modelValue"
         :items="items"
+        aria-labelledby="question-heading"
       />
     </UiQuestion>`,
   }),


### PR DESCRIPTION
### Close #315 

## Scope of work

- change `UiTile` type to type `button`
- in `UiSimpleQuestion` add role `group` to surround answers in one group
- in `UiQuestion`  and  `UiSimpleQuestion` stories I connected the title of the question with group of answers to enable VoiceOver proper reading