### PR TITLE
fix: different focus order in mobile menu side panel

### DIFF
--- a/src/components/organisms/UiHorizontalPaging/UiHorizontalPaging.stories.js
+++ b/src/components/organisms/UiHorizontalPaging/UiHorizontalPaging.stories.js
@@ -1,6 +1,8 @@
 import {
   ref,
+  watch,
   computed,
+  nextTick,
 } from 'vue';
 import UiHorizontalPaging from '@/components/organisms/UiHorizontalPaging/UiHorizontalPaging.vue';
 import UiText from '@/components/atoms/UiText/UiText.vue';
@@ -15,6 +17,7 @@ import UiSidePanel from '@/components/organisms/UiSidePanel/UiSidePanel.vue';
 import UiHorizontalPagingItem from '@/components/organisms/UiHorizontalPaging/_internal/UiHorizontalPagingItem.vue';
 import { actions } from '@storybook/addon-actions';
 import './UiHorizontalPaging.stories.scss';
+import { focusElement } from '../../../utilities/helpers';
 
 const events = actions({ onUpdateModelValue: 'update:modelValue' });
 
@@ -410,6 +413,13 @@ export const AsMobileMenu = {
       const handleBackClick = () => {
         modelValue.value = modelValue.value.slice(0, -1);
       };
+      const backButton = ref(null);
+      watch(isActive, async (active) => {
+        if (active) {
+          await nextTick();
+          focusElement(backButton.value?.$el, true);
+        }
+      });
       return {
         ...args,
         ...events,
@@ -417,6 +427,7 @@ export const AsMobileMenu = {
         modelValue,
         previous,
         isActive,
+        backButton,
         handleBackClick,
       };
     },
@@ -429,7 +440,8 @@ export const AsMobileMenu = {
         <div class="horizontal-paging-as-mobile-menu__title">
           <UiButton
             v-if="isActive"
-            class="ui-button--icon"
+            ref="backButton"
+            class="ui-button--icon horizontal-paging-as-mobile-menu__back"
             @click="handleBackClick"
           >
             <UiIcon

--- a/src/components/organisms/UiHorizontalPaging/UiHorizontalPaging.stories.scss
+++ b/src/components/organisms/UiHorizontalPaging/UiHorizontalPaging.stories.scss
@@ -79,5 +79,10 @@
     display: flex;
     gap: var(--space-12);
   }
+
+  &__back {
+    align-self: flex-start;
+    margin-block-start: 3px;
+  }
 }
 //</Code>

--- a/src/components/organisms/UiHorizontalPaging/_internal/UiHorizontalPagingItem.vue
+++ b/src/components/organisms/UiHorizontalPaging/_internal/UiHorizontalPagingItem.vue
@@ -1,10 +1,4 @@
 <template>
-  <span
-    ref="el"
-    class="visual-hidden"
-    :tabindex="tabindex"
-    @blur="handleA11YHelperBlur"
-  />
   <slot v-if="isActive" />
 </template>
 
@@ -44,17 +38,6 @@ const props = withDefaults(defineProps<HorizontalPangingItemProps>(), {
 });
 const activeItemName = inject<ComputedRef<string>>('activeItemName', computed(() => ''));
 const isActive = computed(() => activeItemName.value === props.name);
-const el = ref<HTMLSpanElement | null>(null);
-const tabindex = ref(0);
-watch(isActive, async (value) => {
-  tabindex.value = 0;
-  if (!value) return;
-  await nextTick();
-  focusElement(el.value);
-});
-const handleA11YHelperBlur = () => {
-  tabindex.value = -1;
-};
 const item = computed(() => ({
   label: props.label,
   title: props.title,

--- a/src/components/organisms/UiSidePanel/UiSidePanel.vue
+++ b/src/components/organisms/UiSidePanel/UiSidePanel.vue
@@ -61,27 +61,6 @@
             }"
           >
             <div class="ui-side-panel__header">
-              <!-- @slot Use this slot to replace close template. -->
-              <slot
-                name="close"
-                v-bind="{
-                  buttonCloseAttrs,
-                  closeHandler,
-                  iconCloseAttrs: defaultProps.iconCloseAttrs,
-                }"
-              >
-                <UiButton
-                  v-bind="buttonCloseAttrs"
-                  ref="button"
-                  class="ui-button--icon ui-button--theme-secondary ui-side-panel__close"
-                  @click="closeHandler"
-                >
-                  <UiIcon
-                    v-bind="defaultProps.iconCloseAttrs"
-                    class="ui-button__icon"
-                  />
-                </UiButton>
-              </slot>
               <!-- @slot Use this slot to replace label template. -->
               <slot
                 name="label"
@@ -128,6 +107,27 @@
                     </UiText>
                   </slot>
                 </div>
+              </slot>
+              <!-- @slot Use this slot to replace close template. -->
+              <slot
+                name="close"
+                v-bind="{
+                  buttonCloseAttrs,
+                  closeHandler,
+                  iconCloseAttrs: defaultProps.iconCloseAttrs,
+                }"
+              >
+                <UiButton
+                  v-bind="buttonCloseAttrs"
+                  ref="button"
+                  class="ui-button--icon ui-button--theme-secondary ui-side-panel__close"
+                  @click="closeHandler"
+                >
+                  <UiIcon
+                    v-bind="defaultProps.iconCloseAttrs"
+                    class="ui-button__icon"
+                  />
+                </UiButton>
               </slot>
             </div>
           </slot>
@@ -353,7 +353,7 @@ onBeforeUnmount(() => {
 
     display: flex;
     flex: none;
-    flex-direction: functions.var($element + "-header", flex-direction, row-reverse);
+    flex-direction: functions.var($element + "-header", flex-direction, row);
     background: functions.var($element + "-header", background, var(--color-background-subtle));
     gap: functions.var($element + "-header", gap, var(--space-16));
 

--- a/src/components/organisms/UiSidePanel/UiSidePanel.vue
+++ b/src/components/organisms/UiSidePanel/UiSidePanel.vue
@@ -350,6 +350,7 @@ onBeforeUnmount(() => {
 
   &__header {
     @include mixins.use-logical($element + "-header", padding, var(--space-20));
+    @include mixins.override-logical('button', null, border-radius, var(--border-radius-form));
 
     display: flex;
     flex: none;


### PR DESCRIPTION
Before this PR I seated focus before content. In design, the focus should be on the back button.  Now everything is adjusted to:
![Zrzut ekranu 2024-01-16 o 11 44 03](https://github.com/infermedica/component-library/assets/12138170/040912df-0934-4386-b6ce-0edc844fd296)
If back button should be focused after page content open then you need upade component in app directly to this changes -> https://github.com/infermedica/component-library/pull/332/commits/6ede363a92536e486e74f6d4701e0dede52eab53 