### PR TITLE
fix: import by alias in UIHorizontalPaging

### DIFF
--- a/src/components/organisms/UiHorizontalPaging/UiHorizontalPaging.vue
+++ b/src/components/organisms/UiHorizontalPaging/UiHorizontalPaging.vue
@@ -114,20 +114,16 @@ import {
   type WritableComputedRef,
   type Ref,
 } from 'vue';
-import UiMenu, { type MenuAttrsProps } from '@/components/organisms/UiMenu/UiMenu.vue';
+import UiMenu, { type MenuAttrsProps } from '../UiMenu/UiMenu.vue';
 import { focusElement } from '../../../utilities/helpers';
 import type {
   Icon,
   DefineAttrsProps,
 } from '../../../types';
-import UiButton from '../../atoms/UiButton/UiButton.vue';
-import type { ButtonAttrsProps } from '../../atoms/UiButton/UiButton.vue';
-import UiIcon from '../../atoms/UiIcon/UiIcon.vue';
-import type { IconAttrsProps } from '../../atoms/UiIcon/UiIcon.vue';
-import UiHeading from '../../atoms/UiHeading/UiHeading.vue';
+import UiButton, { type ButtonAttrsProps } from '../../atoms/UiButton/UiButton.vue';
+import UiIcon, { type IconAttrsProps } from '../../atoms/UiIcon/UiIcon.vue';
 import type { MenuItemAttrsProps } from '../UiMenu/_internal/UiMenuItem.vue';
-import UiHorizontalPagingItem from './_internal/UiHorizontalPagingItem.vue';
-import type { HorizontalPangingItemProps } from './_internal/UiHorizontalPagingItem.vue';
+import UiHorizontalPagingItem, { type HorizontalPangingItemProps } from './_internal/UiHorizontalPagingItem.vue';
 import type { HeadingAttrsProps } from '../../atoms/UiHeading/UiHeading.vue';
 
 export type HorizontalPangingHandleItems = Record<string, HorizontalPangingItemProps>;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { createApp } from 'vue';
-import '@/styles/styles.scss';
+import './styles/styles.scss';
 import App from './App.vue';
 
 const app = createApp(App);

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,25 +1,8 @@
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
-import path from 'path';
 import svgLoader from 'vite-svg-loader';
 
 export default defineConfig({
-  resolve: {
-    alias: [
-      {
-        find: '@',
-        replacement: path.resolve(__dirname, 'src'),
-      },
-      {
-        find: '@sb',
-        replacement: path.resolve(__dirname, '.storybook'),
-      },
-      {
-        find: '@index',
-        replacement: path.resolve(__dirname, './index.ts'),
-      },
-    ],
-  },
   plugins: [
     vue(),
     svgLoader({


### PR DESCRIPTION
# Scope of work
- Remove aliases from the vite. config of Playground App. To detect aliases paths in CL components.
- Use relative path in UiHorizontalPaging
