### PR TITLE
fix: no way to build MobileMenu from design

### DIFF
--- a/src/components/molecules/UiDropdown/UiDropdown.vue
+++ b/src/components/molecules/UiDropdown/UiDropdown.vue
@@ -61,7 +61,7 @@
               { 'ui-menu--compact': isCompact },
             ]"
             :enable-keyboard-navigation="enableKeyboardNavigation"
-            @mounted="handleMenuMounted"
+            @items-loaded="handleMenuItemsNotReachable"
           >
             <template
               v-for="(item, key) in itemsToRender"
@@ -189,7 +189,7 @@ const preventScrollingByArrows = (event: KeyboardEvent) => {
   }
 };
 const menu = ref<MenuInstance | null>(null);
-const handleMenuMounted = () => {
+const handleMenuItemsNotReachable = () => {
   if (!menu.value) return;
   if (menu.value.selectedMenuItem) {
     focusElement(menu.value.selectedMenuItem.$el.querySelector('button'));

--- a/src/components/organisms/UiHorizontalPaging/UiHorizontalPaging.stories.js
+++ b/src/components/organisms/UiHorizontalPaging/UiHorizontalPaging.stories.js
@@ -417,6 +417,8 @@ export const AsMobileMenu = {
       UiHeading,
       UiButton,
       UiIcon,
+      UiMenu,
+      UiLink,
       ForBusiness,
       MedicalCertification,
       InstructionForUse,
@@ -443,6 +445,7 @@ export const AsMobileMenu = {
           focusElement(backButton.value?.$el, true);
         }
       });
+      const menu = ref(null);
       return {
         ...args,
         ...events,
@@ -451,6 +454,7 @@ export const AsMobileMenu = {
         previous,
         isActive,
         backButton,
+        menu,
         handleBackClick,
       };
     },
@@ -482,9 +486,27 @@ export const AsMobileMenu = {
         v-model="modelValue"
         :items="items"
         :has-header="false"
-        :menu-attrs="{enableKeyboardNavigation: true}"
+        :menu-attrs="{ enableKeyboardNavigation: true }"
+        :menu-template-ref="menu"
         @update:modelValue="onUpdateModelValue"
       >
+        <template #menu="{items}">
+          <div class="horizontal-paging-as-mobile-menu__menu">
+            <UiMenu
+              ref="menu"
+              :items="items"
+              class=""
+              :enable-keyboard-navigation="true"
+            />
+            <footer class="horizontal-paging-as-mobile-menu__footer">
+              <UiLink 
+                href="http://infermedica.com" 
+                target="_blank"
+                class="ui-link--theme-secondary"
+              >© 2021 Infermedica</UiLink>
+            </footer>
+          </div>
+        </template>
         <template #languages>
           <Language/>
         </template>
@@ -556,15 +578,15 @@ export const AsMobileMenu = {
         name: 'logo-ut',
         listItemAttrs: { class: 'horizontal-paging-as-mobile-menu__log-out' },
       },
-      {
-        label: '© 2021 Infermedica',
-        tag: UiLink,
-        href: 'https://infermedica.com',
-        target: '_blank',
-        suffixVisible: 'never',
-        class: 'ui-link--small ui-link--theme-secondary horizontal-paging-as-mobile-menu__copyright',
-        listItemAttrs: { class: 'horizontal-paging-as-mobile-menu__footer' },
-      },
+      // {
+      //   label: '© 2021 Infermedica',
+      //   tag: UiLink,
+      //   href: 'https://infermedica.com',
+      //   target: '_blank',
+      //   suffixVisible: 'never',
+      //   class: 'ui-link--small ui-link--theme-secondary horizontal-paging-as-mobile-menu__copyright',
+      //   listItemAttrs: { class: 'horizontal-paging-as-mobile-menu__footer' },
+      // },
     ],
   },
 

--- a/src/components/organisms/UiHorizontalPaging/UiHorizontalPaging.stories.js
+++ b/src/components/organisms/UiHorizontalPaging/UiHorizontalPaging.stories.js
@@ -38,6 +38,7 @@ const Language = {
     return { languages };
   },
   template: `<UiMenu 
+    class="language"
     :items="languages" 
     :enable-keyboard-navigation="true"
   />`,

--- a/src/components/organisms/UiHorizontalPaging/UiHorizontalPaging.stories.js
+++ b/src/components/organisms/UiHorizontalPaging/UiHorizontalPaging.stories.js
@@ -15,6 +15,7 @@ import UiLoader from '@/components/molecules/UiLoader/UiLoader.vue';
 import UiBulletPoints from '@/components/molecules/UiBulletPoints/UiBulletPoints.vue';
 import UiSidePanel from '@/components/organisms/UiSidePanel/UiSidePanel.vue';
 import UiHorizontalPagingItem from '@/components/organisms/UiHorizontalPaging/_internal/UiHorizontalPagingItem.vue';
+import UiLink from '@/components/atoms/UiLink/UiLink.vue';
 import { actions } from '@storybook/addon-actions';
 import './UiHorizontalPaging.stories.scss';
 import UiMenu from '@/components/organisms/UiMenu/UiMenu.vue';
@@ -514,7 +515,9 @@ export const AsMobileMenu = {
         label: 'Languages',
         title: 'Languages',
         name: 'languages',
+        class: '', // override default class `ui-menu-item--theme-secondary`
         suffixAttrs: { label: 'English' },
+        listItemAttrs: { class: 'ui-menu-item horizontal-paging-as-mobile-menu__language' },
       },
       {
         label: 'For business',
@@ -545,6 +548,21 @@ export const AsMobileMenu = {
         label: 'Interview ID',
         title: 'Interview ID',
         name: 'interview-id',
+      },
+      {
+        label: 'Log out',
+        title: 'Log out',
+        name: 'logo-ut',
+        listItemAttrs: { class: 'horizontal-paging-as-mobile-menu__log-out' },
+      },
+      {
+        label: '© 2021 Infermedica',
+        tag: UiLink,
+        href: 'https://infermedica.com',
+        target: '_blank',
+        suffixVisible: 'never',
+        class: 'ui-link--small ui-link--theme-secondary horizontal-paging-as-mobile-menu__copyright',
+        listItemAttrs: { class: 'horizontal-paging-as-mobile-menu__footer' },
       },
     ],
   },

--- a/src/components/organisms/UiHorizontalPaging/UiHorizontalPaging.stories.js
+++ b/src/components/organisms/UiHorizontalPaging/UiHorizontalPaging.stories.js
@@ -490,7 +490,7 @@ export const AsMobileMenu = {
         :menu-template-ref="menu"
         @update:modelValue="onUpdateModelValue"
       >
-        <template #menu="{items}">
+        <template #menu="{items, isActive}">
           <div class="horizontal-paging-as-mobile-menu__menu">
             <UiMenu
               ref="menu"
@@ -500,6 +500,7 @@ export const AsMobileMenu = {
             />
             <footer class="horizontal-paging-as-mobile-menu__footer">
               <UiLink 
+                :tabindex="isActive ? -1 : undefined"
                 href="http://infermedica.com" 
                 target="_blank"
                 class="ui-link--theme-secondary"
@@ -578,15 +579,6 @@ export const AsMobileMenu = {
         name: 'logo-ut',
         listItemAttrs: { class: 'horizontal-paging-as-mobile-menu__log-out' },
       },
-      // {
-      //   label: '© 2021 Infermedica',
-      //   tag: UiLink,
-      //   href: 'https://infermedica.com',
-      //   target: '_blank',
-      //   suffixVisible: 'never',
-      //   class: 'ui-link--small ui-link--theme-secondary horizontal-paging-as-mobile-menu__copyright',
-      //   listItemAttrs: { class: 'horizontal-paging-as-mobile-menu__footer' },
-      // },
     ],
   },
 

--- a/src/components/organisms/UiHorizontalPaging/UiHorizontalPaging.stories.scss
+++ b/src/components/organisms/UiHorizontalPaging/UiHorizontalPaging.stories.scss
@@ -76,6 +76,8 @@
 
 //<Code id="horizontal-paging-as-mobile-menu">
 .horizontal-paging-as-mobile-menu {
+  $element: horizontal-paging-as-mobile-menu;
+
   --side-panel-content-padding-block: 0;
   --side-panel-content-padding-inline: 0;
 
@@ -87,6 +89,12 @@
   &__back {
     align-self: flex-start;
     margin-block-start: 3px;
+  }
+
+  &__menu {
+    @include mixins.use-logical($element + "-menu", padding, var(--space-12) var(--space-4));
+
+    flex: 0 0 100%;
   }
 
   &__language {
@@ -113,18 +121,6 @@
   &__footer {
     padding-inline: var(--space-20);
     padding-block: var(--space-24);
-
-    &::after {
-      border-block: 0;
-    }
-  }
-
-  &__copyright {
-    --list-item-content-background: transparent;
-    --list-item-content-hover-background: transparent;
-    --list-item-content-active-background: transparent;
-    --list-item-content-padding-block: 0;
-    --list-item-content-padding-inline: 0;
   }
 }
 //</Code>

--- a/src/components/organisms/UiHorizontalPaging/UiHorizontalPaging.stories.scss
+++ b/src/components/organisms/UiHorizontalPaging/UiHorizontalPaging.stories.scss
@@ -84,5 +84,43 @@
     align-self: flex-start;
     margin-block-start: 3px;
   }
+
+  &__language {
+    padding-inline: 0.625rem;
+    padding-block-end: var(--space-12);
+    margin-block-end: var(--space-4);
+    margin-inline: calc(var(--space-4) * -1);
+    border: solid var(--color-border-divider);
+    border-width: 0 0 1px 0;
+  }
+
+  &__log-out {
+    padding-inline: var(--space-16);
+    padding-block: var(--space-12);
+    margin-inline: calc(var(--space-8) * -1);
+    border: solid var(--color-border-divider);
+    border-width: 1px 0;
+
+    &::after {
+      border-block: 0;
+    }
+  }
+
+  &__footer {
+    padding-inline: var(--space-20);
+    padding-block: var(--space-24);
+
+    &::after {
+      border-block: 0;
+    }
+  }
+
+  &__copyright {
+    --list-item-content-background: transparent;
+    --list-item-content-hover-background: transparent;
+    --list-item-content-active-background: transparent;
+    --list-item-content-padding-block: 0;
+    --list-item-content-padding-inline: 0;
+  }
 }
 //</Code>

--- a/src/components/organisms/UiHorizontalPaging/UiHorizontalPaging.stories.scss
+++ b/src/components/organisms/UiHorizontalPaging/UiHorizontalPaging.stories.scss
@@ -1,4 +1,8 @@
 @use "../../../styles/mixins";
+.language {
+  margin-block: calc(var(--space-12) * -1);
+  margin-inline: calc(var(--space-16) * -1);
+}
 
 .for-business {
   &__products {

--- a/src/components/organisms/UiHorizontalPaging/UiHorizontalPaging.vue
+++ b/src/components/organisms/UiHorizontalPaging/UiHorizontalPaging.vue
@@ -56,7 +56,10 @@
         <!-- @slot Use this slot to replace menu template. -->
         <slot
           name="menu"
-          v-bind="{ items: menuItems }"
+          v-bind="{
+            items: menuItems,
+            isActive,
+          }"
         >
           <UiMenu
             ref="menu"

--- a/src/components/organisms/UiHorizontalPaging/UiHorizontalPaging.vue
+++ b/src/components/organisms/UiHorizontalPaging/UiHorizontalPaging.vue
@@ -168,6 +168,8 @@ export interface HorizontalPangingProps{
    * Use this props to pass labels inside component translation.
    */
   translation?: HorizontalPagingTranslation;
+  /** Use this props to pass menu template ref when you use menu slot. */
+  menuTemplateRef?: InstanceType<typeof UiMenu> | null
 }
 export type HorizontalPagingAttrsProps = DefineAttrsProps<HorizontalPangingProps>;
 export interface HorizontalPangingEmits {
@@ -184,6 +186,7 @@ const props = withDefaults(defineProps<HorizontalPangingProps>(), {
   headingTitleAttrs: () => ({}),
   menuAttrs: () => ({}),
   translation: () => ({ back: 'Back to' }),
+  menuTemplateRef: null,
 });
 const defaultProps = computed(() => {
   const icon: Icon = 'chevron-left';
@@ -251,17 +254,18 @@ const menuItems = computed<MenuItemAttrsProps[]>(() => itemsAsArray.value.map((i
   };
 }));
 const menu = ref<InstanceType<typeof UiMenu> | null>(null);
+const menuRef = computed(() => (props.menuTemplateRef || menu.value));
 const menuButtons = computed < Record<string, any>>(() => {
-  if (!menu.value) return {};
+  if (!menuRef.value) return {};
   return itemsAsArray.value.reduce((elements, { name }, order) => {
     if (!name
-        || !menu.value
-        || !menu.value.menuItems) {
+        || !menuRef.value
+        || !menuRef.value.menuItems) {
       return elements;
     }
     return {
       ...elements,
-      [name]: menu.value.menuItems[order].$el.querySelector('button'),
+      [name]: menuRef.value.menuItems[order].$el.querySelector('button'),
     };
   }, {});
 });

--- a/src/components/organisms/UiHorizontalPaging/UiHorizontalPaging.vue
+++ b/src/components/organisms/UiHorizontalPaging/UiHorizontalPaging.vue
@@ -236,14 +236,16 @@ const menuItems = computed<MenuItemAttrsProps[]>(() => itemsAsArray.value.map((i
   return {
     icon,
     suffixVisible: 'always',
-    class: 'ui-button--theme-secondary',
+    class: 'ui-menu-item--theme-secondary',
     name: `menu-item-${name}`,
-    onClick: () => {
-      activeItems.value = [
-        ...activeItems.value,
-        item,
-      ];
-    },
+    ...(item.tag ? {} : {
+      onClick: () => {
+        activeItems.value = [
+          ...activeItems.value,
+          item,
+        ];
+      },
+    }),
     ...(isActive.value ? { tabindex: '-1' } : {}),
     ...rest,
   };

--- a/src/components/organisms/UiHorizontalPaging/UiHorizontalPaging.vue
+++ b/src/components/organisms/UiHorizontalPaging/UiHorizontalPaging.vue
@@ -254,20 +254,16 @@ const menuItems = computed<MenuItemAttrsProps[]>(() => itemsAsArray.value.map((i
   };
 }));
 const menu = ref<InstanceType<typeof UiMenu> | null>(null);
-const menuRef = computed(() => (props.menuTemplateRef || menu.value));
-const menuButtons = computed < Record<string, any>>(() => {
+const menuRef = computed<InstanceType<typeof UiMenu> | null>(() => (props.menuTemplateRef || menu.value));
+const menuButtons = computed(() => {
   if (!menuRef.value) return {};
-  return itemsAsArray.value.reduce((elements, { name }, order) => {
-    if (!name
-        || !menuRef.value
-        || !menuRef.value.menuItems) {
-      return elements;
+  const buttons = itemsAsArray.value.reduce<Record<string, HTMLButtonElement | null> | Record<string, never>>((elements, { name }, order) => {
+    if (name && menuRef.value && menuRef.value.menuItems) {
+      elements[name] = menuRef.value.menuItems[order].$el.querySelector('button');
     }
-    return {
-      ...elements,
-      [name]: menuRef.value.menuItems[order].$el.querySelector('button'),
-    };
+    return elements;
   }, {});
+  return buttons;
 });
 watch(activeItemName, async (moveTo, backFrom) => {
   if (backFrom) {

--- a/src/components/organisms/UiHorizontalPaging/UiHorizontalPaging.vue
+++ b/src/components/organisms/UiHorizontalPaging/UiHorizontalPaging.vue
@@ -260,12 +260,14 @@ const menu = ref<InstanceType<typeof UiMenu> | null>(null);
 const menuRef = computed<InstanceType<typeof UiMenu> | null>(() => (props.menuTemplateRef || menu.value));
 const menuButtons = computed(() => {
   if (!menuRef.value) return {};
-  const buttons = itemsAsArray.value.reduce<Record<string, HTMLButtonElement | null> | Record<string, never>>((elements, { name }, order) => {
-    if (name && menuRef.value && menuRef.value.menuItems) {
-      elements[name] = menuRef.value.menuItems[order].$el.querySelector('button');
-    }
-    return elements;
-  }, {});
+  const buttons = itemsAsArray.value
+    .reduce<Record<string, HTMLButtonElement | null> | Record<string, never>>((elements, { name }, order) => {
+      if (name && menuRef.value && menuRef.value.menuItems) {
+        /* eslint-disable-next-line no-param-reassign */
+        elements[name] = menuRef.value.menuItems[order].$el.querySelector('button');
+      }
+      return elements;
+    }, {});
   return buttons;
 });
 watch(activeItemName, async (moveTo, backFrom) => {

--- a/src/components/organisms/UiHorizontalPaging/_internal/UiHorizontalPagingItem.vue
+++ b/src/components/organisms/UiHorizontalPaging/_internal/UiHorizontalPagingItem.vue
@@ -34,7 +34,7 @@ export interface HorizontalPangingItemProps {
    */
   tag?: HTMLTag;
 }
-
+defineOptions({ inheritAttrs: false });
 const props = withDefaults(defineProps<HorizontalPangingItemProps>(), {
   label: '',
   title: '',

--- a/src/components/organisms/UiHorizontalPaging/_internal/UiHorizontalPagingItem.vue
+++ b/src/components/organisms/UiHorizontalPaging/_internal/UiHorizontalPagingItem.vue
@@ -12,7 +12,9 @@ import {
   type ComputedRef,
   useAttrs,
 } from 'vue';
+import UiButton from '../../../atoms/UiButton/UiButton.vue';
 import type { HorizontalPangingHandleItems } from '../UiHorizontalPaging.vue';
+import type { HTMLTag } from '../../../../types';
 
 export interface HorizontalPangingItemProps {
   /**
@@ -27,18 +29,26 @@ export interface HorizontalPangingItemProps {
    * Use this props to set inside pages item name.
    */
   name?: string;
+  /**
+   * Use this props to set list item content tag.
+   */
+  tag?: HTMLTag;
 }
 
 const props = withDefaults(defineProps<HorizontalPangingItemProps>(), {
   label: '',
   title: '',
   name: '',
+  tag: UiButton,
 });
 const attrs = useAttrs();
 const activeItemName = inject<ComputedRef<string>>('activeItemName', computed(() => ''));
 const isActive = computed(() => activeItemName.value === props.name);
 const item = computed(() => ({
-  ...props,
+  label: props.label,
+  title: props.title,
+  name: props.title,
+  ...(props.tag === UiButton ? {} : { tag: props.tag }),
   ...attrs,
 }));
 const items = inject<Ref<HorizontalPangingHandleItems>>('items', ref({}));

--- a/src/components/organisms/UiHorizontalPaging/_internal/UiHorizontalPagingItem.vue
+++ b/src/components/organisms/UiHorizontalPaging/_internal/UiHorizontalPagingItem.vue
@@ -47,7 +47,7 @@ const isActive = computed(() => activeItemName.value === props.name);
 const item = computed(() => ({
   label: props.label,
   title: props.title,
-  name: props.title,
+  name: props.name,
   ...(props.tag === UiButton ? {} : { tag: props.tag }),
   ...attrs,
 }));

--- a/src/components/organisms/UiMenu/UiMenu.vue
+++ b/src/components/organisms/UiMenu/UiMenu.vue
@@ -101,31 +101,53 @@ const {
   nextMenuItem,
   prevMenuItem,
   selectedMenuItem,
+  focusedMenuItem,
 } = useMenuItems(mItems);
-const handleMenuKeydown = ({ key }: KeyboardEvent) => {
+const handleMenuKeydown = async ({ key }: KeyboardEvent) => {
   if (!props.enableKeyboardNavigation) return;
   switch (key) {
     case 'ArrowUp':
       if (prevMenuItem.value) {
+        focusedMenuItem.value.tabindex = -1;
+        prevMenuItem.value.tabindex = 0;
         focusElement(prevMenuItem.value.$el.querySelector('button'));
       }
       break;
     case 'ArrowDown':
       if (nextMenuItem.value) {
+        focusedMenuItem.value.tabindex = -1;
+        nextMenuItem.value.tabindex = 0;
         focusElement(nextMenuItem.value.$el.querySelector('button'));
       }
       break;
     case 'Home':
     case 'PageUp':
       if (firstMenuItem.value) {
+        focusedMenuItem.value.tabindex = -1;
+        firstMenuItem.value.tabindex = 0;
         focusElement(firstMenuItem.value.$el.querySelector('button'));
       }
       break;
     case 'End':
     case 'PageDown':
       if (lastMenuItem.value) {
+        focusedMenuItem.value.tabindex = -1;
+        lastMenuItem.value.tabindex = 0;
         focusElement(lastMenuItem.value.$el.querySelector('button'));
       }
+      break;
+    case 'Tab':
+      const lastFocusedElement = ref(focusedMenuItem.value);
+      setTimeout(() => {
+        lastFocusedElement.value.tabindex = -1;
+        if (selectedMenuItem.value) {
+          selectedMenuItem.value.tabindex = 0;
+          return;
+        }
+        if (firstMenuItem.value) {
+          firstMenuItem.value.tabindex = 0;
+        }
+      }, 0);
       break;
     default: break;
   }

--- a/src/components/organisms/UiMenu/UiMenu.vue
+++ b/src/components/organisms/UiMenu/UiMenu.vue
@@ -39,7 +39,6 @@
 import {
   ref,
   computed,
-  onMounted,
   provide,
   nextTick,
   watch,
@@ -137,13 +136,13 @@ defineExpose({
   selectedMenuItem,
 });
 export interface MenuEmits {
-  (e: 'mounted'): void;
+  (e: 'itemsNotReachable'): void;
 }
 const emit = defineEmits<MenuEmits>();
 const hasMenuItems = computed(() => (
   menuItems.value.length > 0
 ));
-const makeItemsUnacessibleForTab = () => {
+const setItemsNotReachable = () => {
   [ ...menuItems.value ].forEach((item) => {
     item.tabindex = item.$el.querySelector('button') ? -1 : 0;
   });
@@ -152,15 +151,12 @@ const makeItemsUnacessibleForTab = () => {
   } else {
     firstMenuItem.value.tabindex = 0;
   }
+  emit('itemsNotReachable');
 };
-onMounted(async () => {
-  if (!props.enableKeyboardNavigation) return;
-  emit('mounted');
-});
 watch(hasMenuItems, async (hasItems) => {
   if (hasItems) {
     await nextTick();
-    makeItemsUnacessibleForTab();
+    setItemsNotReachable();
   }
 });
 </script>

--- a/src/components/organisms/UiMenu/UiMenu.vue
+++ b/src/components/organisms/UiMenu/UiMenu.vue
@@ -145,7 +145,7 @@ const hasMenuItems = computed(() => (
 ));
 const makeItemsUnacessibleForTab = () => {
   [ ...menuItems.value ].forEach((item) => {
-    item.tabindex = -1;
+    item.tabindex = item.$el.querySelector('button') ? -1 : 0;
   });
   if (selectedMenuItem.value) {
     selectedMenuItem.value.tabindex = 0;

--- a/src/components/organisms/UiMenu/UiMenu.vue
+++ b/src/components/organisms/UiMenu/UiMenu.vue
@@ -136,7 +136,7 @@ defineExpose({
   selectedMenuItem,
 });
 export interface MenuEmits {
-  (e: 'itemsNotReachable'): void;
+  (e: 'itemsLoaded'): void;
 }
 const emit = defineEmits<MenuEmits>();
 const hasMenuItems = computed(() => (
@@ -151,7 +151,7 @@ const setItemsNotReachable = () => {
   } else {
     firstMenuItem.value.tabindex = 0;
   }
-  emit('itemsNotReachable');
+  emit('itemsLoaded');
 };
 watch(hasMenuItems, async (hasItems) => {
   if (hasItems) {

--- a/src/components/organisms/UiMenu/useMenuItems.js
+++ b/src/components/organisms/UiMenu/useMenuItems.js
@@ -21,7 +21,7 @@ export default function useMenuItems(menuItems) {
       : menuItems.value[activeMenuItemIndex.value - 1]));
   const selectedMenuItem = computed(
     () => [ ...menuItems.value ].find(
-      (item) => item.$el.querySelector('button').classList.contains('ui-menu-item--is-selected'),
+      (item) => item.$el.querySelector('button')?.classList.contains('ui-menu-item--is-selected'),
     ),
   );
 


### PR DESCRIPTION
# Scope of work
* Make changes required to build MobileMenu from the design
* Extend the story "As Mobile Menu" to elements from the design
# Screens of visual changes
![Zrzut ekranu 2024-01-25 o 23 10 20](https://github.com/infermedica/component-library/assets/12138170/e1cca6f3-94ae-43ab-bbc0-723626356d19)
![Zrzut ekranu 2024-01-25 o 23 10 32](https://github.com/infermedica/component-library/assets/12138170/f93646f7-ccee-4596-8742-57ca3300966c)
