### PR TITLE
fix: problem with UiPopover width in UiDatepicker and UiPhoneNumber

### DIFF
--- a/src/components/molecules/UiPhoneNumber/_internal/UiPhoneNumberPrefix/UiPhoneNumberPrefix.vue
+++ b/src/components/molecules/UiPhoneNumber/_internal/UiPhoneNumberPrefix/UiPhoneNumberPrefix.vue
@@ -107,7 +107,8 @@ onMounted(async () => {
   &__popover {
     @include mixins.override-logical('popover', null, border-width, 0);
 
-    --dropdown-popover-width: 100%;
+    --dropdown-popover-width: #{functions.var($element + "-popover", width, 100% )};
+    --dropdown-popover-max-width: #{functions.var($element + "-popover", max-width, 100% )};
     --dropdown-popover-min-height: #{functions.var($element + '-popover', min-height, 12.5rem)};
 
     z-index: functions.var($element + '-popover', z-index, 1);

--- a/src/components/organisms/UiDatepicker/_internal/UiDatepickerCalendar.vue
+++ b/src/components/organisms/UiDatepicker/_internal/UiDatepickerCalendar.vue
@@ -267,6 +267,7 @@ const clickOutsideValue = computed<VClickOutsideValue>(() => ({
   @include mixins.override-logical(dropdown-popover, $element + "-popover", padding, 0);
 
   --dropdown-popover-width: #{functions.var($element + "-popover", width, 100% )};
+  --dropdown-popover-max-width: #{functions.var($element + "-popover", max-width, 100% )};
 
   position: unset;
 }


### PR DESCRIPTION
**Related issue**
Closes #358 

**Scope of work**
Use `--ui-dropdown-popover-max-width` to set Popover width to 100% in 'UiDatepickerCalendar` and `UiPhoneNumberPrefix`

**Screenshots of visual changes**
![Zrzut ekranu 2024-02-8 o 10 23 54](https://github.com/infermedica/component-library/assets/12138170/303ce692-1a15-40f9-8205-4be307c37538)
![Zrzut ekranu 2024-02-8 o 10 23 38](https://github.com/infermedica/component-library/assets/12138170/6d8a4890-a65c-4494-a54a-b67da6a1afd6)
