### PR TITLE
fix UiAlert attributes for Screen Readers

### DIFF
--- a/src/components/molecules/UiAlert/UiAlert.vue
+++ b/src/components/molecules/UiAlert/UiAlert.vue
@@ -2,7 +2,7 @@
   <div
     class="ui-alert"
     :class="rootClassModifier"
-    role="alert"
+    v-bind="alertAttrs"
   >
     <!-- @slot Use this slot to replace icon template. -->
     <slot
@@ -32,7 +32,10 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import {
+  computed,
+  type HTMLAttributes,
+} from 'vue';
 import UiIcon from '../../atoms/UiIcon/UiIcon.vue';
 import type { IconAttrsProps } from '../../atoms/UiIcon/UiIcon.vue';
 import UiText from '../../atoms/UiText/UiText.vue';
@@ -76,6 +79,10 @@ const defaultProps = computed(() => ({
     ...props.iconAlertAttrs,
   },
 }));
+const alertAttrs = computed<HTMLAttributes>(() => ((props.type !== 'error') ? ({}) : ({
+  role: 'alert',
+  'aria-live': 'polite',
+})));
 </script>
 
 <style lang="scss">

--- a/src/components/molecules/UiAlert/UiAlert.vue
+++ b/src/components/molecules/UiAlert/UiAlert.vue
@@ -62,6 +62,10 @@ export interface AlertProps {
    * Use this props to pass attrs for message UiText
    */
   textMessageAttrs?: TextAttrsProps;
+  /**
+   * Use this props to pass HTML attrs
+   */
+   alertAttrs?: HTMLAttributes;
 }
 export type AlertAttrsProps = DefineAttrsProps<AlertProps>;
 
@@ -70,6 +74,10 @@ const props = withDefaults(defineProps<AlertProps>(), {
   hasIcon: true,
   iconAlertAttrs: () => ({}),
   textMessageAttrs: () => ({}),
+  alertAttrs: () => ({
+    role: 'alert',
+    'aria-live': 'polite',
+  }),
 });
 const rootClassModifier = computed(() => `ui-alert--${props.type}`);
 const icon = computed<IconName>(() => ((!props.hasIcon || props.type === 'default') ? '' : `${props.type}-filled`));
@@ -79,10 +87,6 @@ const defaultProps = computed(() => ({
     ...props.iconAlertAttrs,
   },
 }));
-const alertAttrs = computed<HTMLAttributes>(() => ((props.type !== 'error') ? ({}) : ({
-  role: 'alert',
-  'aria-live': 'polite',
-})));
 </script>
 
 <style lang="scss">


### PR DESCRIPTION
## Description
UiAlert add alerts attributes as a `props`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
An accessibility improvement for  Screen Readers

## Screenshots (if appropriate):
Not needed

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
