### PR TITLE
fix: focus on the input checkbox persists to another element in the parent wrapper is focused

### DIFF
--- a/src/components/atoms/UiCheckbox/UiCheckbox.vue
+++ b/src/components/atoms/UiCheckbox/UiCheckbox.vue
@@ -264,7 +264,7 @@ defineExpose({ input });
   }
 
   @include mixins.with-focus {
-    &:focus-within {
+    &:focus-within:has(input[type="checkbox"]:focus) {
       #{$this}__checkbox {
         box-shadow: var(--focus-outer);
       }


### PR DESCRIPTION
## Description
It fixes the bug, which was about having two elements being focused at the same time (visually) because of the checkbox div wrapper. One line of code.

## BEFORE:
https://github.com/infermedica/component-library/assets/13744352/b668f395-f089-47da-96c2-3dd6b61c011a

## AFTER:
https://github.com/infermedica/component-library/assets/13744352/a220e084-6117-4f51-9036-c09fe48c7fdc



## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Closes #

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
