### PR TITLE
chore: run release GH Action for merged release PRs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,14 +1,13 @@
 name: Release
 on:
-  push:
-    branches-ignore:
-      - main
-      - develop
-    tags:
-      - v*
+  pull-request:
+    branches:
+      - `release/**`
+    types:
+      - closed
 jobs:
-  build:
-    name: Create release
+  if-merged:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Description
The "Release" GitHub Action will be triggered for closed pull requests from branches prefixed with release/**. The "if-merged" section will execute steps exclusively for merged pull requests.

## Related Issue
Closes #383 

## Motivation and Context
We'll automatically release the Component Library once it receives 2 approvals. That's the plan.

## How Has This Been Tested?

## Screenshots (if appropriate):

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
