### PR TITLE
fix: redundant label tag in UiMultipleChoicesItem option UiListItem

### DIFF
--- a/src/components/molecules/UiBulletPoints/UiBulletPoints.vue
+++ b/src/components/molecules/UiBulletPoints/UiBulletPoints.vue
@@ -163,7 +163,6 @@ const itemsToRender = computed<BulletPointsRenderItem[]>(() => (
     };
   })));
 const bulletPointsItemAttrs = ({
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   name, text, children, ...itemAttrs
 }: BulletPointsRenderItem) => itemAttrs;
 </script>

--- a/src/components/molecules/UiDropdown/UiDropdown.vue
+++ b/src/components/molecules/UiDropdown/UiDropdown.vue
@@ -325,7 +325,6 @@ const itemsToRender = computed<DropdownItemComplex[]>(() => (props.items.map((it
   };
 })));
 const dropdownItemAttrs = ({
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   name, text, ...itemAttrs
 }: DropdownItemComplex) => itemAttrs;
 </script>

--- a/src/components/organisms/UiControls/UiControls.vue
+++ b/src/components/organisms/UiControls/UiControls.vue
@@ -166,7 +166,6 @@ const layoutComponent = computed(() => (
 
 const layoutProps = computed(() => {
   const {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     layout, containerAttrs, ...rest
   } = props;
   return {

--- a/src/components/organisms/UiList/UiList.vue
+++ b/src/components/organisms/UiList/UiList.vue
@@ -92,7 +92,6 @@ const itemsToRender = computed<ListRenderItem[]>(() => (props.items.map((item, k
   };
 })));
 const listItemAttrs = ({
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   name, label, children, ...rest
 }: ListRenderItem) => rest;
 </script>

--- a/src/components/organisms/UiMultipleChoices/_internal/UiMultipleChoicesItem.vue
+++ b/src/components/organisms/UiMultipleChoices/_internal/UiMultipleChoicesItem.vue
@@ -102,7 +102,7 @@
             <UiListItem
               ref="content"
               v-model="value"
-              v-bind="option"
+              v-bind="listItemOptionAttrs(option)"
               :tag="UiRadio"
               :class="[
                 'ui-multiple-choices-item__option-content', {
@@ -295,6 +295,11 @@ const optionsToRender = computed(() => props.options.map((option) => ({
     ...option.inputAttrs,
   },
 })));
+
+const listItemOptionAttrs = ({
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  label, ...rest
+}: ListItemAttrsProps) => rest;
 
 const content = ref<typeof UiRadio | null>(null);
 

--- a/src/components/organisms/UiMultipleChoices/_internal/UiMultipleChoicesItem.vue
+++ b/src/components/organisms/UiMultipleChoices/_internal/UiMultipleChoicesItem.vue
@@ -297,7 +297,6 @@ const optionsToRender = computed(() => props.options.map((option) => ({
 })));
 
 const listItemOptionAttrs = ({
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   label, ...rest
 }: ListItemAttrsProps) => rest;
 

--- a/src/components/organisms/UiSimpleQuestion/UiSimpleQuestion.vue
+++ b/src/components/organisms/UiSimpleQuestion/UiSimpleQuestion.vue
@@ -99,7 +99,6 @@ const updateHandler = (value: SimpleQuestionProps['modelValue']) => {
   emit('update:modelValue', value);
 };
 const tileItemAttrs = ({
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   label, ...itemAttrs
 }: SimpleQuestionItem) => itemAttrs;
 const itemsToRender = computed(() => props.items);


### PR DESCRIPTION
## Description
Filter redundant `label` from `option` object 

## Related Issue
Closes #381

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate):
![Zrzut ekranu 2024-02-29 o 12 50 53](https://github.com/infermedica/component-library/assets/12138170/df3e5590-49f7-46bf-b4a6-6a067df528c9)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
