### PR TITLE
fix: accessibility improvements in UiScale component

### DIFF
--- a/src/components/molecules/UiScale/UiScale.vue
+++ b/src/components/molecules/UiScale/UiScale.vue
@@ -1,9 +1,6 @@
 <!-- eslint-disable vuejs-accessibility/mouse-events-have-key-events -->
 <template>
-  <div
-    class="ui-scale"
-    role="radiogroup"
-  >
+  <div class="ui-scale">
     <component
       :is="tag"
       class="ui-scale__controls"
@@ -48,7 +45,6 @@
             #label="{ textLabelAttrs }"
           >
             <UiText
-              :id="`scale-label-${index}`"
               v-bind="textLabelAttrs"
               :class="[
                 'ui-scale__label', { 'ui-scale__label--is-checked': index === scaleValue },
@@ -271,7 +267,6 @@ const itemsToRender = computed<RadioAttrsProps[]>(() => (Array.from({ length: ma
     ? props.radioOptionAttrs[index]
     : props.radioOptionAttrs;
   return {
-    'aria-labelledby': `scale-label-${index}`,
     ...radioOptionAttrs,
     textLabelAttrs: {
       tag: 'div',


### PR DESCRIPTION
## Description
This PR organizes accessibility topics in UiScale.
Based on this article https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/radiogroup_role#examples when we use `fieldset` and `legend`, `role="radiogoup"` is not necessary. 

## Related Issue
Closes #

## Motivation and Context

## How Has This Been Tested?
Use VoiceOver


## Screenshots (if appropriate):
before, has "grupa" on end
![Kapture 2024-03-12 at 13 22 43](https://github.com/infermedica/component-library/assets/12138170/4534fd78-2ff5-4b9b-aaea-836b25096a84)
after, without "grupa" on end
![Kapture 2024-03-12 at 13 24 33](https://github.com/infermedica/component-library/assets/12138170/00f3d7db-c0fd-4720-8619-ac0c92f9ba46)
## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
