### PR TITLE
fix: add focus to the first invalid input in UiMultipleChoices

### DIFF
--- a/src/components/organisms/UiMultipleChoices/UiMultipleChoices.vue
+++ b/src/components/organisms/UiMultipleChoices/UiMultipleChoices.vue
@@ -43,7 +43,7 @@
           }"
         >
           <UiMultipleChoicesItem
-            :ref="(el)=>{ setFirstMultipleAnswerItemRef(el, index) }"
+            :ref="(el)=>{ setFirstMultipleAnswerItemRef(el, index, hasError(index)) }"
             :model-value="value[index]"
             v-bind="item"
             :options="options"
@@ -144,12 +144,13 @@ const updateHandler = (newValue: MultipleChoicesModelValue, index: number) => {
 const setFirstMultipleAnswerItemRef = (
   el: Element | ComponentPublicInstance | null,
   idx: number,
+  elHasError: boolean,
 ) => {
   if (!el) return;
 
   const multipleChoicesItem = el as InstanceType<typeof UiMultipleChoicesItem>;
 
-  if (multipleChoicesItem.content && multipleChoicesItem.content[0].content && multipleChoicesItem.invalid) {
+  if (multipleChoicesItem.content && multipleChoicesItem.content[0].content && elHasError) {
     invalidMultipleChoicesItemRefs.set(idx, multipleChoicesItem.content[0].content.input);
   }
 };

--- a/src/components/organisms/UiMultipleChoices/_internal/UiMultipleChoicesItem.vue
+++ b/src/components/organisms/UiMultipleChoices/_internal/UiMultipleChoicesItem.vue
@@ -302,10 +302,7 @@ const listItemOptionAttrs = ({
 
 const content = ref<typeof UiRadio | null>(null);
 
-defineExpose({
-  content,
-  invalid: props.invalid,
-});
+defineExpose({ content });
 </script>
 
 <style lang="scss">


### PR DESCRIPTION
## Description
This pull request addresses the issue of adding focus to the first invalid input in UiMultipleChoices when there is an error status.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Closes #429 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In stories and an application

## Screenshots (if appropriate):
The solution checked in the application:

https://github.com/infermedica/component-library/assets/37744371/855d6315-734a-4f75-8cd8-8eaf3f386743



## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
