### PR TITLE
fix: lazy-loaded UiLoader in UiButton

### DIFF
--- a/src/components/atoms/UiButton/UiButton.vue
+++ b/src/components/atoms/UiButton/UiButton.vue
@@ -86,15 +86,12 @@ const {
   componentTag,
   routeAttrs,
 } = useLink(props);
-const hasLoader = ref(false);
+const hasLoader = ref(props.isLoading);
 watch(() => (props.isLoading), (isLoading) => {
   if (isLoading && !hasLoader.value) {
     hasLoader.value = true;
   }
-}, {
-  immediate: true,
-  once: true,
-});
+}, { once: true });
 const loader = computed(() => (
   hasLoader.value
     ? defineAsyncComponent(() => import('../../molecules/UiLoader/UiLoader.vue'))


### PR DESCRIPTION
## Description
Watch on `props.isLoading` with `immediate` and `once` are mutually exclusive. This PR solves this issue

## Related Issue

## Motivation and Context

## How Has This Been Tested?
1. Set `isLoading` https://component.infermedica.com/?path=/docs/atoms-button--docs and you should see no changes.
2. Run this PR and set `isLoading`. I think everything should work well. 

## Screenshots (if appropriate):

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
