### PR TITLE
fix: add attributes for legend

### DIFF
--- a/src/components/molecules/UiScale/UiScale.vue
+++ b/src/components/molecules/UiScale/UiScale.vue
@@ -8,11 +8,15 @@
       <!-- @slot Use this slot to replace legend template. -->
       <slot
         name="legend"
-        v-bind="{ legend }"
+        v-bind="{
+          legend,
+          legendAttrs,
+        }"
       >
         <legend
           v-if="legend"
           class="visual-hidden"
+          v-bind="legendAttrs"
         >
           {{ legend }}
         </legend>
@@ -186,6 +190,10 @@ export interface ScaleProps {
    */
   legend?: string;
   /**
+   * Use this props to add attributes for the legend.
+   */
+   legendAttrs?: Record<string, unknown>;
+  /**
    * Use this props to pass attrs for option UiRadio.
    */
   radioOptionAttrs?: RadioAttrsProps | RadioAttrsProps[];
@@ -217,6 +225,7 @@ const props = withDefaults(defineProps<ScaleProps>(), {
   }),
   tag: 'fieldset',
   legend: '',
+  legendAttrs: () => ({}),
   radioOptionAttrs: () => ([]),
   textMinAttrs: () => ({}),
   textMaxAttrs: () => ({}),


### PR DESCRIPTION
## Description
This prop allows to pass attributes for `legend`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Closes #439 

## Motivation and Context
This attribute is necessary to fix errors reported by EqualWeb plugin

## How Has This Been Tested?
Use the EqualWeb plugin in the story

## Screenshots (if appropriate):
Before:
<img width="945" alt="image" src="https://github.com/infermedica/component-library/assets/37744371/d1b9786f-1686-4e84-97a8-88b82a3cf0c1">
<img width="1497" alt="image" src="https://github.com/infermedica/component-library/assets/37744371/8a3422ec-f583-48db-a1d0-35e5938641a1">

After:
<img width="984" alt="image" src="https://github.com/infermedica/component-library/assets/37744371/1b957ad4-f55b-4d3d-80c7-25c385a18c68">
<img width="1503" alt="image" src="https://github.com/infermedica/component-library/assets/37744371/58602f6d-4acc-4494-8add-c75e53d0f08c">

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
