### PR TITLE
fix: jumping UiButton size when importing the loader

### DIFF
--- a/src/components/atoms/UiButton/UiButton.vue
+++ b/src/components/atoms/UiButton/UiButton.vue
@@ -30,11 +30,13 @@
 
 <script setup lang="ts">
 import {
+  h,
   ref,
   computed,
   watch,
   type HTMLAttributes,
   defineAsyncComponent,
+  useSlots,
 } from 'vue';
 import type {
   HTMLTag,
@@ -92,9 +94,14 @@ watch(() => (props.isLoading), (isLoading) => {
     hasLoader.value = true;
   }
 }, { once: true });
+const slot = useSlots();
 const loader = computed(() => (
   hasLoader.value
-    ? defineAsyncComponent(() => import('../../molecules/UiLoader/UiLoader.vue'))
+    ? defineAsyncComponent({
+      loader: () => import('../../molecules/UiLoader/UiLoader.vue'),
+      delay: 0,
+      loadingComponent: () => h('slot', slot.default()),
+    })
     : null
 ));
 

--- a/src/components/atoms/UiButton/UiButton.vue
+++ b/src/components/atoms/UiButton/UiButton.vue
@@ -94,13 +94,16 @@ watch(() => (props.isLoading), (isLoading) => {
     hasLoader.value = true;
   }
 }, { once: true });
-const slot = useSlots();
+const slots = useSlots();
 const loader = computed(() => (
   hasLoader.value
     ? defineAsyncComponent({
       loader: () => import('../../molecules/UiLoader/UiLoader.vue'),
       delay: 0,
-      loadingComponent: () => h('slot', slot.default()),
+      loadingComponent: () => (slots.default
+        ? h('slot', slots.default())
+        : null)
+      ,
     })
     : null
 ));


### PR DESCRIPTION
## Description
Maintain the default slot the until UiLoader is imported.

## Related Issue
Closes #

## Motivation and Context
Button size will change to smallest size before UiLoader is imported.

## How Has This Been Tested?


## Screenshots (if appropriate):

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
