### PR TITLE
refactor: simplify MultipleChoices implementation and improve stories

### DIFF
--- a/src/components/organisms/UiMultipleChoices/UiMultipleChoices.stories.js
+++ b/src/components/organisms/UiMultipleChoices/UiMultipleChoices.stories.js
@@ -7,6 +7,7 @@ import {
   ref,
   computed,
   nextTick,
+  onMounted,
 } from 'vue';
 import { actions } from '@storybook/addon-actions';
 import { modifiers } from '@sb/helpers/argTypes';
@@ -130,16 +131,14 @@ export const WithError = {
       const invalidChoices = ref(null);
 
       const handleSubmit = async () => {
-        await focusOnInvalidChoice(invalidChoices);
         const { focusInvalidInput } = focusOnInvalidChoice(invalidChoices);
-
-        // Note: Two nextTick functions are required to focus on the first invalid input after page load.
-        await nextTick();
-        await nextTick();
         focusInvalidInput();
       };
 
-      handleSubmit();
+      onMounted(async () => {
+        await nextTick();
+        handleSubmit();
+      });
 
       return {
         ...args,
@@ -176,14 +175,13 @@ export const WithOneCorrectAnswerAndErrors = {
 
       const handleSubmit = async () => {
         const { focusInvalidInput } = focusOnInvalidChoice(invalidChoices);
-
-        // Note: Two nextTick functions are required to focus on the first invalid input after page load.
-        await nextTick();
-        await nextTick();
         focusInvalidInput();
       };
 
-      handleSubmit();
+      onMounted(async () => {
+        await nextTick();
+        handleSubmit();
+      });
 
       return {
         ...args,
@@ -500,14 +498,13 @@ export const StackedWithError = {
 
       const handleSubmit = async () => {
         const { focusInvalidInput } = focusOnInvalidChoice(invalidChoices);
-
-        // Note: Two nextTick functions are required to focus on the first invalid input after page load.
-        await nextTick();
-        await nextTick();
         focusInvalidInput();
       };
 
-      handleSubmit();
+      onMounted(async () => {
+        await nextTick(); // Wait for child element to mount as well
+        handleSubmit();
+      });
 
       return {
         ...args,

--- a/src/components/organisms/UiMultipleChoices/UiMultipleChoices.vue
+++ b/src/components/organisms/UiMultipleChoices/UiMultipleChoices.vue
@@ -125,7 +125,7 @@ const props = withDefaults(defineProps<MultipleChoicesProps>(), {
 });
 const emit = defineEmits<MultipleChoicesEmits>();
 
-const multipleChoicesItemRefs = ref([]);
+const multipleChoicesItemRefs = ref<InstanceType<typeof UiMultipleChoicesItem>[]>([]);
 
 const value = computed<MultipleChoicesModelValue[]>(() => (JSON.parse(JSON.stringify(props.modelValue))));
 const valid = computed(() => (value.value.filter(

--- a/src/components/organisms/UiMultipleChoices/UiMultipleChoices.vue
+++ b/src/components/organisms/UiMultipleChoices/UiMultipleChoices.vue
@@ -43,7 +43,7 @@
           }"
         >
           <UiMultipleChoicesItem
-            :ref="(el)=>{ setInvalidMultipleChoicesItemsRef(el, index, hasError(index)) }"
+            ref="multipleChoicesItemRefs"
             :model-value="value[index]"
             v-bind="item"
             :options="options"
@@ -60,8 +60,7 @@
 import {
   computed,
   watch,
-  type ComponentPublicInstance,
-  reactive,
+  ref,
 } from 'vue';
 import UiText from '../../atoms/UiText/UiText.vue';
 import UiAlert from '../../molecules/UiAlert/UiAlert.vue';
@@ -126,7 +125,7 @@ const props = withDefaults(defineProps<MultipleChoicesProps>(), {
 });
 const emit = defineEmits<MultipleChoicesEmits>();
 
-const invalidInputsRefs = reactive<InvalidInputs>(new Map());
+const multipleChoicesItemRefs = ref([]);
 
 const value = computed<MultipleChoicesModelValue[]>(() => (JSON.parse(JSON.stringify(props.modelValue))));
 const valid = computed(() => (value.value.filter(
@@ -146,26 +145,9 @@ const updateHandler = (newValue: MultipleChoicesModelValue, index: number) => {
 };
 
 function focusInvalidChoice() {
-  if (invalidInputsRefs.size > 0) {
-    const element = [ ...invalidInputsRefs.values() ][0];
-    focusElement(element, true);
-  }
+  const firstInvalidChoice = multipleChoicesItemRefs.value.find((element, index) => hasError(index));
+  if (firstInvalidChoice) focusElement(firstInvalidChoice.$el.querySelector('input'), true);
 }
-
-const setInvalidMultipleChoicesItemsRef = (
-  el: Element | ComponentPublicInstance | null,
-  idx: number,
-  elHasError: boolean,
-) => {
-  if (!el) return;
-
-  const multipleChoicesItem = el as InstanceType<typeof UiMultipleChoicesItem>;
-
-  if (multipleChoicesItem.content && multipleChoicesItem.content[0].content && elHasError) {
-    invalidInputsRefs.set(idx, multipleChoicesItem.content[0].content.input);
-  }
-  if (!elHasError) invalidInputsRefs.delete(idx);
-};
 
 defineExpose<ExposedTypes>({ focusInvalidChoice });
 </script>

--- a/src/components/organisms/UiMultipleChoices/UiMultipleChoices.vue
+++ b/src/components/organisms/UiMultipleChoices/UiMultipleChoices.vue
@@ -146,7 +146,14 @@ const updateHandler = (newValue: MultipleChoicesModelValue, index: number) => {
 
 function focusInvalidChoice() {
   const firstInvalidChoice = multipleChoicesItemRefs.value.find((element, index) => hasError(index));
-  if (firstInvalidChoice) focusElement(firstInvalidChoice.$el.querySelector('input'), true);
+  if (!firstInvalidChoice) return;
+
+  const choicesFirstRadioItem = firstInvalidChoice?.content?.at(0);
+  const firstRadioItemsInput = choicesFirstRadioItem?.content?.input;
+
+  const elementToFocus = firstRadioItemsInput ?? firstInvalidChoice.$el.querySelector('input');
+
+  focusElement(elementToFocus, true);
 }
 
 defineExpose<ExposedTypes>({ focusInvalidChoice });


### PR DESCRIPTION
## Description
1. Simplifies MultipleChoice code and function by removing `invalidInputsRefs` state
2. Changes stories from using `nextTick` too often

## Motivation and Context
`invalidInputsRefs` state was cause of previous bug and after some thoughts, it seems unnecessary. We don't do anything with it until `focusInvalidChoice`, so generating it earlier and updating it doesn't have any value.

Additionally this PR makes `handleSubmit` look identically as in MGP, and moves `nextTick` to happen only once, on mount.

## Related Issue
Improves https://github.com/infermedica/component-library/issues/432, although it could already be closed

## Checklist:

- [✅] My code follows the style guidelines of this project
- [✅] I have performed a self-review of my code
- [NA] I have made corresponding changes to the documentation
- [✅] My changes generate no new warnings
- [NA] I have added tests that prove my fix is effective or that my feature works
- [✅] New and existing unit tests pass locally with my changes
