### PR TITLE
fix: character counter centered relative to the error message

### DIFF
--- a/src/components/molecules/UiFormField/UiFormField.vue
+++ b/src/components/molecules/UiFormField/UiFormField.vue
@@ -216,7 +216,6 @@ const handleErrorEmit = (error: string | null) => {
 
   &__messages {
     display: flex;
-    align-items: center;
     justify-content: space-between;
     gap: var(--space-8);
   }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Character counters are centered relative to the error message. Issue for longes error messages. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Closes #

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Before
![Zrzut ekranu 2024-04-16 o 15 43 41](https://github.com/infermedica/component-library/assets/12138170/06231761-a811-40dc-9030-f64194084487)
After
![Zrzut ekranu 2024-04-16 o 15 43 58](https://github.com/infermedica/component-library/assets/12138170/0e3d0fd5-7117-439e-b7ec-a0b2af9a8877)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
