### PR TITLE
fix: objects with functions cant be equal

### DIFF
--- a/src/utilities/helpers/equal/index.ts
+++ b/src/utilities/helpers/equal/index.ts
@@ -1,4 +1,9 @@
 import { deepEqual } from 'fast-equals';
 
 // eslint-disable-next-line import/prefer-default-export
-export const equal = deepEqual;
+export const equal = <A, B>(a: A, b: B): boolean => (
+  deepEqual(
+    JSON.parse(JSON.stringify(a)),
+    JSON.parse(JSON.stringify(b)),
+  )
+);


### PR DESCRIPTION
## Description
equal() has a problem comparing object with functions. To solve this issue I use "JSON" trick to remove functions

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Closes #

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
