### PR TITLE
fix: the explanation icon overlaps with a string

### DIFF
--- a/src/components/organisms/UiList/_internal/UiListItemAffix.vue
+++ b/src/components/organisms/UiList/_internal/UiListItemAffix.vue
@@ -22,10 +22,11 @@
 <script setup lang="ts">
 import {
   computed,
-  defineAsyncComponent,
   useAttrs,
 } from 'vue';
-import UiIcon, { type IconAttrsProps } from '../../../atoms/UiIcon/UiIcon.vue';
+import { type IconAttrsProps } from '../../../atoms/UiIcon/UiIcon.vue';
+import UiButton from '../../../atoms/UiButton/UiButton.vue';
+import UiText from '../../../atoms/UiText/UiText.vue';
 
 import type {
   DefineAttrsProps,
@@ -73,8 +74,8 @@ const listItemAffixComponent = computed(() => {
     return props.tag;
   }
   return isButton.value
-    ? defineAsyncComponent(() => import('../../../atoms/UiButton/UiButton.vue'))
-    : defineAsyncComponent(() => import('../../../atoms/UiText/UiText.vue'));
+    ? UiButton
+    : UiText;
 });
 const defaultProps = computed(() => ({
   iconAttrs: {

--- a/src/components/organisms/UiList/_internal/UiListItemPrefix.vue
+++ b/src/components/organisms/UiList/_internal/UiListItemPrefix.vue
@@ -65,7 +65,7 @@ defineExpose({ listItemPrefixTemplateRefs });
   $this: &;
   $element: list-item-prefix;
 
-  --list-item-affix-gap: functions.var($element, gap);
+  --list-item-affix-gap: #{functions.var($element, gap)};
   --list-item-affix-icon-color: #{functions.var($element, icon-color)};
   --list-item-affix-hover-icon-color: #{functions.var($element + '-hover', icon-color)};
   --list-item-affix-active-icon-color: #{functions.var($element + '-active', icon-color)};

--- a/src/components/organisms/UiList/_internal/UiListItemPrefix.vue
+++ b/src/components/organisms/UiList/_internal/UiListItemPrefix.vue
@@ -1,5 +1,6 @@
 <template>
   <UiListItemAffix
+    ref="listItemPrefixTemplateRefs"
     class="ui-list-item-prefix"
   >
     <template
@@ -45,11 +46,15 @@
 </template>
 
 <script setup lang="ts">
+import { ref } from 'vue';
 import UiListItemAffix, { type ListItemAffixAttrsProps } from '@/components/organisms/UiList/_internal/UiListItemAffix.vue';
 import UiIcon from '../../../atoms/UiIcon/UiIcon.vue';
 import type { DefineAttrsProps } from '../../../../types';
 
 export type ListItemPrefixAttrsProps = DefineAttrsProps<ListItemAffixAttrsProps>
+
+const listItemPrefixTemplateRefs = ref(null);
+defineExpose({ listItemPrefixTemplateRefs });
 </script>
 
 <style scoped lang="scss">

--- a/src/components/organisms/UiList/_internal/UiListItemPrefix.vue
+++ b/src/components/organisms/UiList/_internal/UiListItemPrefix.vue
@@ -1,6 +1,6 @@
 <template>
   <UiListItemAffix
-    ref="listItemPrefixTemplateRefs"
+    ref="listItemPrefixTemplateRef"
     class="ui-list-item-prefix"
   >
     <template
@@ -53,8 +53,8 @@ import type { DefineAttrsProps } from '../../../../types';
 
 export type ListItemPrefixAttrsProps = DefineAttrsProps<ListItemAffixAttrsProps>
 
-const listItemPrefixTemplateRefs = ref(null);
-defineExpose({ listItemPrefixTemplateRefs });
+const listItemPrefixTemplateRef = ref(null);
+defineExpose({ listItemPrefixTemplateRef });
 </script>
 
 <style scoped lang="scss">

--- a/src/components/organisms/UiList/_internal/UiListItemSuffix.vue
+++ b/src/components/organisms/UiList/_internal/UiListItemSuffix.vue
@@ -1,6 +1,6 @@
 <template>
   <UiListItemAffix
-    ref="listItemSuffixTemplateRefs"
+    ref="listItemSuffixTemplateRef"
     class="ui-list-item-suffix"
   >
     <template
@@ -79,8 +79,8 @@ if (Object.keys(props.labelSuffixAttrs).length > 0) {
   console.warn('[@infermedica/component-library]: The `labelSuffixAttrs` props is deprecated and it will be removed in v2.0.0. Please use `labelAttrs` instead.');
 }
 // END
-const listItemSuffixTemplateRefs = ref<ComponentInstance<typeof UiListItemAffix> | null>(null);
-defineExpose({ listItemSuffixTemplateRefs });
+const listItemSuffixTemplateRef = ref<ComponentInstance<typeof UiListItemAffix> | null>(null);
+defineExpose({ listItemSuffixTemplateRef });
 </script>
 
 <style scoped lang="scss">

--- a/src/components/organisms/UiList/_internal/UiListItemSuffix.vue
+++ b/src/components/organisms/UiList/_internal/UiListItemSuffix.vue
@@ -46,7 +46,10 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import {
+  type ComponentInstance,
+  ref,
+} from 'vue';
 import UiListItemAffix, { type ListItemAffixAttrsProps } from '@/components/organisms/UiList/_internal/UiListItemAffix.vue';
 import UiIcon, { type IconAttrsProps } from '../../../atoms/UiIcon/UiIcon.vue';
 import type { DefineAttrsProps } from '../../../../types';
@@ -76,7 +79,7 @@ if (Object.keys(props.labelSuffixAttrs).length > 0) {
   console.warn('[@infermedica/component-library]: The `labelSuffixAttrs` props is deprecated and it will be removed in v2.0.0. Please use `labelAttrs` instead.');
 }
 // END
-const listItemSuffixTemplateRefs = ref(null);
+const listItemSuffixTemplateRefs = ref<ComponentInstance<typeof UiListItemAffix> | null>(null);
 defineExpose({ listItemSuffixTemplateRefs });
 </script>
 

--- a/src/components/organisms/UiList/_internal/UiListItemSuffix.vue
+++ b/src/components/organisms/UiList/_internal/UiListItemSuffix.vue
@@ -88,7 +88,7 @@ defineExpose({ listItemSuffixTemplateRefs });
   $this: &;
   $element: list-item-suffix;
 
-  --list-item-affix-gap: functions.var($element, gap);
+  --list-item-affix-gap: #{functions.var($element, gap)};
   --list-item-affix-icon-color: #{functions.var($element, icon-color)};
   --list-item-affix-hover-icon-color: #{functions.var($element + '-hover', icon-color)};
   --list-item-affix-active-icon-color: #{functions.var($element + '-active', icon-color)};

--- a/src/components/organisms/UiList/_internal/UiListItemSuffix.vue
+++ b/src/components/organisms/UiList/_internal/UiListItemSuffix.vue
@@ -1,5 +1,6 @@
 <template>
   <UiListItemAffix
+    ref="listItemSuffixTemplateRefs"
     class="ui-list-item-suffix"
   >
     <template
@@ -45,6 +46,7 @@
 </template>
 
 <script setup lang="ts">
+import { ref } from 'vue';
 import UiListItemAffix, { type ListItemAffixAttrsProps } from '@/components/organisms/UiList/_internal/UiListItemAffix.vue';
 import UiIcon, { type IconAttrsProps } from '../../../atoms/UiIcon/UiIcon.vue';
 import type { DefineAttrsProps } from '../../../../types';
@@ -74,6 +76,8 @@ if (Object.keys(props.labelSuffixAttrs).length > 0) {
   console.warn('[@infermedica/component-library]: The `labelSuffixAttrs` props is deprecated and it will be removed in v2.0.0. Please use `labelAttrs` instead.');
 }
 // END
+const listItemSuffixTemplateRefs = ref(null);
+defineExpose({ listItemSuffixTemplateRefs });
 </script>
 
 <style scoped lang="scss">

--- a/src/components/organisms/UiMultipleAnswer/_internal/UiMultipleAnswerItem.vue
+++ b/src/components/organisms/UiMultipleAnswer/_internal/UiMultipleAnswerItem.vue
@@ -59,7 +59,7 @@
       >
         <UiListItemSuffix
           v-if="hasSuffix"
-          ref="suffixTemplateRefs"
+          ref="suffixTemplateRef"
           v-bind="suffixAttrs"
           class="ui-multiple-answer-item__suffix"
         />
@@ -189,8 +189,8 @@ const errorClass = computed(() => (props.invalid
   : []));
 const content = ref<InstanceType<typeof component.value> | null>(null);
 defineExpose({ content });
-const suffixTemplateRefs = ref<ComponentInstance<typeof UiListItemSuffix> | null>(null);
-const suffixEl = computed(() => (suffixTemplateRefs.value?.listItemSuffixTemplateRefs?.$el));
+const suffixTemplateRef = ref<ComponentInstance<typeof UiListItemSuffix> | null>(null);
+const suffixEl = computed(() => (suffixTemplateRef.value?.listItemSuffixTemplateRef?.$el));
 const suffixSize = computed(() => {
   const size = suffixEl.value?.getBoundingClientRect();
   const width = suffixEl.value ? size.width : 0;

--- a/src/components/organisms/UiMultipleAnswer/_internal/UiMultipleAnswerItem.vue
+++ b/src/components/organisms/UiMultipleAnswer/_internal/UiMultipleAnswerItem.vue
@@ -57,12 +57,11 @@
           suffixAttrs,
         }"
       >
-        <component
-          :is="suffixComponent"
+        <UiListItemSuffix
           v-if="hasSuffix"
-          ref="suffix"
+          ref="suffixTemplateRefs"
           v-bind="suffixAttrs"
-          class="ui-list-item__suffix ui-multiple-answer-item__suffix"
+          class="ui-multiple-answer-item__suffix"
         />
       </slot>
     </template>
@@ -83,9 +82,10 @@ import type { ButtonAttrsProps } from '../../../atoms/UiButton/UiButton.vue';
 import type { IconAttrsProps } from '../../../atoms/UiIcon/UiIcon.vue';
 import type { MultipleAnswerModelValue } from '../UiMultipleAnswer.vue';
 import UiCheckbox from '../../../atoms/UiCheckbox/UiCheckbox.vue';
+import UiRadio from '../../../atoms/UiRadio/UiRadio.vue';
 import UiListItem from '../../UiList/_internal/UiListItem.vue';
 import type { ListItemAttrsProps } from '../../UiList/_internal/UiListItem.vue';
-import UiRadio from '../../../atoms/UiRadio/UiRadio.vue';
+import UiListItemSuffix from '../../UiList/_internal/UiListItemSuffix.vue';
 import type {
   DefineAttrsProps,
   HTMLTag,
@@ -188,16 +188,26 @@ const errorClass = computed(() => (props.invalid
   : []));
 const content = ref<InstanceType<typeof component.value> | null>(null);
 defineExpose({ content });
-const suffix = ref<ComponentPublicInstance | null>(null);
-const suffixSize = ref({
-  '--_label-suffix-width': '0',
-  '--_label-suffix-height': '0',
+const suffixTemplateRefs = ref(null);
+const suffixEl = computed(() => (suffixTemplateRefs.value?.listItemSuffixTemplateRefs?.$el));
+const suffixSize = computed(() => {
+  let width = 0;
+  let height = 0;
+  if (suffixEl.value) {
+    const size = suffixEl.value.getBoundingClientRect();
+    width = size.width;
+    height = size.height;
+  }
+  return {
+    '--_label-suffix-width': `${width}px`,
+    '--_label-suffix-height': `${height}px`,
+  };
 });
 const handleInfoFocus = (event: KeyboardEvent) => {
   if (event.key !== 'ArrowRight') return;
-  if (suffix.value?.$el) {
+  if (suffixEl.value) {
     event.preventDefault();
-    focusElement(suffix.value.$el);
+    focusElement(suffixEl.value);
   }
 };
 const handleInfoUnfocus = (event: KeyboardEvent) => {
@@ -226,18 +236,6 @@ const suffixAttrs = computed(() => ({
   ...props.buttonInfoAttrs,
 }));
 const hasInfo = computed(() => (Object.keys(props.buttonInfoAttrs).length > 0));
-onMounted(async () => {
-  await nextTick();
-  if (suffix.value?.$el) {
-    const {
-      width, height,
-    } = suffix.value.$el.getBoundingClientRect();
-    suffixSize.value = {
-      '--_label-suffix-width': `${width}px`,
-      '--_label-suffix-height': `${height}px`,
-    };
-  }
-});
 const listItemAttrs = computed(() => ({
   class: [
     'ui-multiple-answer-item',
@@ -258,7 +256,7 @@ const listItemAttrs = computed(() => ({
   &--has-info {
     #{$this}__label {
       &::after {
-        @include mixins.use-logical($element + "-suffix", margin, 0 0 0 var(--space-12));
+        @include mixins.use-logical($element + "-suffix", margin, 0 var(--space-8) 0 var(--space-12));
 
         width: var(--_label-suffix-width);
         height: var(--_label-suffix-height);

--- a/src/components/organisms/UiMultipleAnswer/_internal/UiMultipleAnswerItem.vue
+++ b/src/components/organisms/UiMultipleAnswer/_internal/UiMultipleAnswerItem.vue
@@ -75,6 +75,7 @@ import {
   onMounted,
   nextTick,
   type ComponentPublicInstance,
+  type ComponentInstance,
 } from 'vue';
 import { focusElement } from '../../../../utilities/helpers';
 import type { TextAttrsProps } from '../../../atoms/UiText/UiText.vue';
@@ -188,7 +189,7 @@ const errorClass = computed(() => (props.invalid
   : []));
 const content = ref<InstanceType<typeof component.value> | null>(null);
 defineExpose({ content });
-const suffixTemplateRefs = ref(null);
+const suffixTemplateRefs = ref<ComponentInstance<typeof UiListItemSuffix> | null>(null);
 const suffixEl = computed(() => (suffixTemplateRefs.value?.listItemSuffixTemplateRefs?.$el));
 const suffixSize = computed(() => {
   let width = 0;

--- a/src/components/organisms/UiMultipleAnswer/_internal/UiMultipleAnswerItem.vue
+++ b/src/components/organisms/UiMultipleAnswer/_internal/UiMultipleAnswerItem.vue
@@ -192,13 +192,9 @@ defineExpose({ content });
 const suffixTemplateRefs = ref<ComponentInstance<typeof UiListItemSuffix> | null>(null);
 const suffixEl = computed(() => (suffixTemplateRefs.value?.listItemSuffixTemplateRefs?.$el));
 const suffixSize = computed(() => {
-  let width = 0;
-  let height = 0;
-  if (suffixEl.value) {
-    const size = suffixEl.value.getBoundingClientRect();
-    width = size.width;
-    height = size.height;
-  }
+  const size = suffixEl.value?.getBoundingClientRect();
+  const width = suffixEl.value ? size.width : 0;
+  const height = suffixEl.value ? size.height : 0;
   return {
     '--_label-suffix-width': `${width}px`,
     '--_label-suffix-height': `${height}px`,
@@ -206,10 +202,9 @@ const suffixSize = computed(() => {
 });
 const handleInfoFocus = (event: KeyboardEvent) => {
   if (event.key !== 'ArrowRight') return;
-  if (suffixEl.value) {
-    event.preventDefault();
-    focusElement(suffixEl.value);
-  }
+  if (!suffixEl.value) return;
+  event.preventDefault();
+  focusElement(suffixEl.value);
 };
 const handleInfoUnfocus = (event: KeyboardEvent) => {
   if (event.key !== 'ArrowLeft') return;


### PR DESCRIPTION
## Description
UiMultipleAnswareItem can't get UiListItemSuffix template refs to get it size.

## Related Issue
Closes #476 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
<img width="524" alt="Zrzut ekranu 2024-05-10 o 11 28 34" src="https://github.com/infermedica/component-library/assets/12138170/3aeb39d6-c892-411a-bdd5-0d6fa161b0b3">
<img width="336" alt="Zrzut ekranu 2024-05-10 o 11 28 59" src="https://github.com/infermedica/component-library/assets/12138170/5f051d43-bf99-479e-afad-d8525e5578bb">


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
