### PR TITLE
fix: textarea resize issue

### DIFF
--- a/src/components/atoms/UiTextarea/UiTextarea.stories.ts
+++ b/src/components/atoms/UiTextarea/UiTextarea.stories.ts
@@ -34,7 +34,7 @@ const meta = {
   args: {
     ...args,
     modelValue: '',
-    resize: false,
+    resize: 'vertical',
     placeholder: 'Please provide a detailed description of the issue.',
     textareaAttrs: { 'data-testid': 'textarea-element' },
   },
@@ -71,7 +71,6 @@ export const Basic: TextareaStoryType = {
   },
 };
 Basic.decorators = [ withVModel ];
-Basic.args = { resize: 'vertical' };
 Basic.parameters = { docs: { source: { code: BasicStoriesSource } } };
 
 export const Empty: TextareaStoryType = { ...Basic };

--- a/src/components/atoms/UiTextarea/UiTextarea.stories.ts
+++ b/src/components/atoms/UiTextarea/UiTextarea.stories.ts
@@ -71,6 +71,7 @@ export const Basic: TextareaStoryType = {
   },
 };
 Basic.decorators = [ withVModel ];
+Basic.args = { resize: 'vertical' };
 Basic.parameters = { docs: { source: { code: BasicStoriesSource } } };
 
 export const Empty: TextareaStoryType = { ...Basic };

--- a/src/components/atoms/UiTextarea/UiTextarea.vue
+++ b/src/components/atoms/UiTextarea/UiTextarea.vue
@@ -84,7 +84,7 @@ export interface Size {
 
 const props = withDefaults(defineProps<TextareaProps>(), {
   modelValue: '',
-  resize: false,
+  resize: 'vertical',
   placeholder: '',
   disabled: false,
   hasAutogrowing: false,
@@ -123,6 +123,9 @@ const textareaSize:Size = reactive({
   height: null,
   minHeight: null,
 });
+
+const textareaMargin = '2px';
+
 const setTextareaSize = (mutationList: MutationRecord[]) => {
   const { style } = mutationList[0].target as HTMLElement;
   const {
@@ -130,7 +133,7 @@ const setTextareaSize = (mutationList: MutationRecord[]) => {
   } = style;
 
   const calcHeightPx = Number(height.replace('px', ''));
-  const calcMinHeightPx = Number(minHeight.replace('px', '')) + 4;
+  const calcMinHeightPx = Number(minHeight.replace('px', '')) + (2 * Number(textareaMargin.replace('px', '')));
   const calcHeight = calcHeightPx > calcMinHeightPx ? null : `${calcMinHeightPx}px`;
 
   textareaSize.width = width;
@@ -192,10 +195,10 @@ defineExpose({ textarea });
     @include mixins.use-logical($element, padding, var(--space-12) var(--space-16));
     @include mixins.use-logical($element, border, 0);
 
-    margin: var(--space-2);
+    margin: v-bind(textareaMargin);
     overflow: hidden;
     overflow-y: auto;
-    max-width: calc(100% - var(--space-4));
+    max-width: calc(100% - (2 * v-bind(textareaMargin)));
     border-radius: inherit;
     background: transparent;
     caret-color: functions.var($element, caret-color, var(--color-blue-500));

--- a/src/components/atoms/UiTextarea/UiTextarea.vue
+++ b/src/components/atoms/UiTextarea/UiTextarea.vue
@@ -14,7 +14,10 @@
       v-keyboard-focus
       v-bind="defaultProps.textareaAttrs"
       :value="modelValue"
-      :style="{ resize: resizeValue }"
+      :style="{
+        resize: resizeValue,
+        'min-height': rootStyle.minHeight,
+      }"
       class="ui-textarea__textarea"
       @input="inputHandler($event)"
     />
@@ -76,6 +79,7 @@ export interface TextareaEmits {
 export interface Size {
   width: string | null;
   height: string | null;
+  minHeight: string | null;
 }
 
 const props = withDefaults(defineProps<TextareaProps>(), {
@@ -117,24 +121,33 @@ const textarea = ref<HTMLTextAreaElement | null>(null);
 const textareaSize:Size = reactive({
   width: null,
   height: null,
+  minHeight: null,
 });
 const setTextareaSize = (mutationList: MutationRecord[]) => {
   const { style } = mutationList[0].target as HTMLElement;
   const {
-    width, height,
+    width, height, minHeight,
   } = style;
+
+  const calcHeightPx = Number(height.replace('px', ''));
+  const calcMinHeightPx = Number(minHeight.replace('px', '')) + 4;
+  const calcHeight = calcHeightPx > calcMinHeightPx ? null : `${calcMinHeightPx}px`;
+
   textareaSize.width = width;
-  textareaSize.height = height;
+  textareaSize.height = calcHeight;
+  textareaSize.minHeight = minHeight;
 };
 const rootStyle = computed(() => (props.hasAutogrowing ? {} : {
   width: textareaSize.width,
   height: textareaSize.height,
+  minHeight: textareaSize.minHeight,
 }));
 const observer = new MutationObserver(setTextareaSize);
 onMounted(async () => {
   if (props.hasAutogrowing) { return; }
   await nextTick();
   if (textarea.value) {
+    textareaSize.minHeight = `${textarea.value.offsetHeight}px`;
     observer.observe(textarea.value, {
       attributes: true,
       childList: false,
@@ -145,9 +158,7 @@ onMounted(async () => {
 onBeforeUnmount(() => {
   observer.disconnect();
 });
-defineExpose(
-  textarea,
-);
+defineExpose({ textarea });
 </script>
 
 <style lang="scss">
@@ -181,8 +192,10 @@ defineExpose(
     @include mixins.use-logical($element, padding, var(--space-12) var(--space-16));
     @include mixins.use-logical($element, border, 0);
 
+    margin: var(--space-2);
     overflow: hidden;
-    max-width: 100%;
+    overflow-y: auto;
+    max-width: calc(100% - var(--space-4));
     border-radius: inherit;
     background: transparent;
     caret-color: functions.var($element, caret-color, var(--color-blue-500));


### PR DESCRIPTION
## Description
The `min-height` for `textarea` is set when the component is displayed for the first time
Add `overflow-y: scroll` to enable scrolling functionality

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Closes #462 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
