### PR TITLE
fix: typo in defineExpose in UiTextarea

### DIFF
--- a/src/components/atoms/UiTextarea/UiTextarea.vue
+++ b/src/components/atoms/UiTextarea/UiTextarea.vue
@@ -145,9 +145,7 @@ onMounted(async () => {
 onBeforeUnmount(() => {
   observer.disconnect();
 });
-defineExpose(
-  textarea,
-);
+defineExpose({ textarea });
 </script>
 
 <style lang="scss">


### PR DESCRIPTION
## Description
exposed object in UiTextarea

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Closes #

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
