### PR TITLE
refactor: replace i18n-iso-countries with Intl.DisplayNames

### DIFF
--- a/.github/workflows/storybook-manual.yaml
+++ b/.github/workflows/storybook-manual.yaml
@@ -1,0 +1,43 @@
+name: Deploy Storybook Manual
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v4
+        with:
+          version: 7
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build
+        run: pnpm run build-storybook
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './storybook-static'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "dotenv": "^16.0.3",
     "fast-equals": "^5.0.1",
     "google-libphonenumber": "^3.2.33",
-    "i18n-iso-countries": "^7.7.0",
     "sass": "^1.32.7",
     "uid": "^2.0.2",
     "vite-svg-loader": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ dependencies:
   google-libphonenumber:
     specifier: ^3.2.33
     version: 3.2.34
-  i18n-iso-countries:
-    specifier: ^7.7.0
-    version: 7.10.0
   sass:
     specifier: ^1.32.7
     version: 1.71.1
@@ -3641,7 +3638,7 @@ packages:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.4.21(typescript@5.2.2)
-      vue-component-type-helpers: 2.0.19
+      vue-component-type-helpers: 2.0.26
     transitivePeerDependencies:
       - encoding
       - prettier
@@ -4171,35 +4168,16 @@ packages:
       pretty-format: 29.7.0
     dev: true
 
-  /@volar/language-core@1.11.1:
-    resolution: {integrity: sha512-dOcNn3i9GgZAcJt43wuaEykSluAuOkQgzni1cuxLxTV0nJKanQztp7FxyswdRILaKH+P2XZMPRp2S4MV/pElCw==}
-    dependencies:
-      '@volar/source-map': 1.11.1
-    dev: true
-
   /@volar/language-core@2.2.5:
     resolution: {integrity: sha512-2htyAuxRrAgETmFeUhT4XLELk3LiEcqoW/B8YUXMF6BrGWLMwIR09MFaZYvrA2UhbdAeSyeQ726HaWSWkexUcQ==}
     dependencies:
       '@volar/source-map': 2.2.5
     dev: true
 
-  /@volar/source-map@1.11.1:
-    resolution: {integrity: sha512-hJnOnwZ4+WT5iupLRnuzbULZ42L7BWWPMmruzwtLhJfpDVoZLjNBxHDi2sY2bgZXCKlpU5XcsMFoYrsQmPhfZg==}
-    dependencies:
-      muggle-string: 0.3.1
-    dev: true
-
   /@volar/source-map@2.2.5:
     resolution: {integrity: sha512-wrOEIiZNf4E+PWB0AxyM4tfhkfldPsb3bxg8N6FHrxJH2ohar7aGu48e98bp3pR9HUA7P/pR9VrLmkTrgCCnWQ==}
     dependencies:
       muggle-string: 0.4.1
-    dev: true
-
-  /@volar/typescript@1.11.1:
-    resolution: {integrity: sha512-iU+t2mas/4lYierSnoFOeRFQUhAEMgsFuQxoxvwn5EdQopw43j+J27a4lt9LMInx1gLJBC6qL14WYGlgymaSMQ==}
-    dependencies:
-      '@volar/language-core': 1.11.1
-      path-browserify: 1.0.1
     dev: true
 
   /@volar/typescript@2.2.5:
@@ -4359,26 +4337,6 @@ packages:
       vue-eslint-parser: 9.4.2(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@vue/language-core@1.8.27(typescript@5.2.2):
-    resolution: {integrity: sha512-L8Kc27VdQserNaCUNiSFdDl9LWT24ly8Hpwf1ECy3aFb9m6bDhBGQYOujDm21N7EW3moKIOKEanQwe1q5BK+mA==}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@volar/language-core': 1.11.1
-      '@volar/source-map': 1.11.1
-      '@vue/compiler-dom': 3.4.21
-      '@vue/shared': 3.4.21
-      computeds: 0.0.1
-      minimatch: 9.0.3
-      muggle-string: 0.3.1
-      path-browserify: 1.0.1
-      typescript: 5.2.2
-      vue-template-compiler: 2.7.16
     dev: true
 
   /@vue/language-core@2.0.19(typescript@5.2.2):
@@ -5916,10 +5874,6 @@ packages:
       dequal: 2.0.3
     dev: true
 
-  /diacritics@1.3.0:
-    resolution: {integrity: sha512-wlwEkqcsaxvPJML+rDh/2iS824jbREk6DUMUKkEaSlxdYHeS43cClJtsWglvw2RfeXGm6ohKDqsXteJ5sP5enA==}
-    dev: false
-
   /didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
     dev: true
@@ -7403,13 +7357,6 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
     dev: true
-
-  /i18n-iso-countries@7.10.0:
-    resolution: {integrity: sha512-Y4wkIS2MzYk7cvaV665qcHpBUK4FaMcAhSfsggu9SPV9VpWvmH8NklofWvPPFWG1ZXmxqZ0Ubgr+ZtqddxG4ag==}
-    engines: {node: '>= 12'}
-    dependencies:
-      diacritics: 1.3.0
-    dev: false
 
   /iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -8932,10 +8879,6 @@ packages:
 
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-    dev: true
-
-  /muggle-string@0.3.1:
-    resolution: {integrity: sha512-ckmWDJjphvd/FvZawgygcUeQCxzvohjFO5RxTjj4eq8kw359gFF3E1brjfI+viLMxss5JrHTDRHZvu2/tuy0Qg==}
     dev: true
 
   /muggle-string@0.4.1:
@@ -11938,6 +11881,10 @@ packages:
 
   /vue-component-type-helpers@2.0.19:
     resolution: {integrity: sha512-cN3f1aTxxKo4lzNeQAkVopswuImUrb5Iurll9Gaw5cqpnbTAxtEMM1mgi6ou4X79OCyqYv1U1mzBHJkzmiK82w==}
+    dev: true
+
+  /vue-component-type-helpers@2.0.26:
+    resolution: {integrity: sha512-sO9qQ8oC520SW6kqlls0iqDak53gsTVSrYylajgjmkt1c0vcgjsGSy1KzlDrbEx8pm02IEYhlUkU5hCYf8rwtg==}
     dev: true
 
   /vue-docgen-api@4.75.1(vue@3.4.21):

--- a/src/components/molecules/UiPhoneNumber/UiPhoneNumber.stories.ts
+++ b/src/components/molecules/UiPhoneNumber/UiPhoneNumber.stories.ts
@@ -3,11 +3,8 @@ import type {
   Meta,
   StoryObj,
 } from '@storybook/vue3';
-import { Alpha2Code } from 'i18n-iso-countries';
-import polishCountriesTranslation from 'i18n-iso-countries/langs/pl.json';
 import UiPhoneNumber from './UiPhoneNumber.vue';
 import UiFormField from '../UiFormField/UiFormField.vue';
-import { i18nCountries } from './helpers';
 
 const customCountryCodeItems: Alpha2Code[] = [
   'AF',
@@ -85,7 +82,6 @@ export const WithTranslatedCountryNames: StoryObj<typeof UiPhoneNumber> = {
         UiPhoneNumber,
       },
       setup() {
-        i18nCountries.registerLocale(polishCountriesTranslation);
         return { args };
       },
       template: `<UiFormField

--- a/src/components/molecules/UiPhoneNumber/UiPhoneNumber.vue
+++ b/src/components/molecules/UiPhoneNumber/UiPhoneNumber.vue
@@ -38,7 +38,6 @@ import {
   useAttrs,
 } from 'vue';
 import { uid } from 'uid/single';
-import type { Alpha2Code } from 'i18n-iso-countries';
 import UiPhoneNumberPrefix from './_internal/UiPhoneNumberPrefix/UiPhoneNumberPrefix.vue';
 import UiPhoneNumberInput from './_internal/UiPhoneNumberInput/UiPhoneNumberInput.vue';
 import type { DefineAttrsProps } from '../../../types';
@@ -68,7 +67,7 @@ export interface PhoneNumberProps {
   /**
    * Use this props to set countries available on dropdown.
    */
-  countryCodes?: Alpha2Code[],
+  countryCodes?: string,
 }
 export type PhoneNumberAttrsProps = DefineAttrsProps<PhoneNumberProps>;
 

--- a/src/components/molecules/UiPhoneNumber/UiPhoneNumber.vue
+++ b/src/components/molecules/UiPhoneNumber/UiPhoneNumber.vue
@@ -67,7 +67,7 @@ export interface PhoneNumberProps {
   /**
    * Use this props to set countries available on dropdown.
    */
-  countryCodes?: string,
+  countryCodes?: string[],
 }
 export type PhoneNumberAttrsProps = DefineAttrsProps<PhoneNumberProps>;
 

--- a/src/components/molecules/UiPhoneNumber/_internal/UiPhoneNumberPrefix/UiPhoneNumberPrefix.vue
+++ b/src/components/molecules/UiPhoneNumber/_internal/UiPhoneNumberPrefix/UiPhoneNumberPrefix.vue
@@ -40,7 +40,6 @@ import {
   computed,
   onMounted,
 } from 'vue';
-import type { Alpha2Code } from 'i18n-iso-countries';
 import UiDropdown from '../../../UiDropdown/UiDropdown.vue';
 import UiPhoneNumberPrefixToggle from './UiPhoneNumberPrefixToggle.vue';
 import {
@@ -61,7 +60,7 @@ export interface PhoneNumberPrefixProps {
   /**
    * Use this props to set country code items.
    */
-  countryCodes?: Alpha2Code[],
+  countryCodes?: string[],
   /**
    * Use this props to set error state.
    */

--- a/src/components/molecules/UiPhoneNumber/_internal/UiPhoneNumberPrefix/UiPhoneNumberPrefixToggle.vue
+++ b/src/components/molecules/UiPhoneNumber/_internal/UiPhoneNumberPrefix/UiPhoneNumberPrefixToggle.vue
@@ -75,11 +75,11 @@ const icon = computed(() => (props.isOpen ? 'chevron-up' : 'chevron-down'));
 
   &--error {
     --button-border-block-color: #{functions.var($element, border-color, var(--color-border-error-strong))};
-  --button-border-inline-color: #{functions.var($element, border-color, var(--color-border-error-strong))};
-  --button-hover-border-block-color: #{functions.var($element, border-color, var(--color-border-error-strong))};
-  --button-hover-border-inline-color: #{functions.var($element, border-color, var(--color-border-error-strong))};
-  --button-active-border-block-color: #{functions.var($element, border-color, var(--color-border-error-strong))};
-  --button-active-border-inline-color: #{functions.var($element, border-color, var(--color-border-error-strong))};
+    --button-border-inline-color: #{functions.var($element, border-color, var(--color-border-error-strong))};
+    --button-hover-border-block-color: #{functions.var($element, border-color, var(--color-border-error-strong))};
+    --button-hover-border-inline-color: #{functions.var($element, border-color, var(--color-border-error-strong))};
+    --button-active-border-block-color: #{functions.var($element, border-color, var(--color-border-error-strong))};
+    --button-active-border-inline-color: #{functions.var($element, border-color, var(--color-border-error-strong))};
   }
 
   &__icon {

--- a/src/components/molecules/UiPhoneNumber/helpers/get-phone-codes.spec.ts
+++ b/src/components/molecules/UiPhoneNumber/helpers/get-phone-codes.spec.ts
@@ -1,8 +1,4 @@
-import polishCountriesTranslation from 'i18n-iso-countries/langs/pl.json';
-import {
-  getCountriesInfo,
-  i18nCountries,
-} from './index';
+import { getCountriesInfo } from './index';
 
 describe('helpers/getCountriesInfo', () => {
   it('returns an array of phone codes with default settings', async () => {
@@ -13,7 +9,6 @@ describe('helpers/getCountriesInfo', () => {
   });
 
   it('returns an array of phone codes with the correct language passed', async () => {
-    i18nCountries.registerLocale(polishCountriesTranslation);
     const phoneCodes = getCountriesInfo([], 'pl');
 
     expect(phoneCodes).toBeInstanceOf(Array);

--- a/src/components/molecules/UiPhoneNumber/helpers/index.ts
+++ b/src/components/molecules/UiPhoneNumber/helpers/index.ts
@@ -1,6 +1,3 @@
-import * as i18nCountries from 'i18n-iso-countries';
-import type { Alpha2Code } from 'i18n-iso-countries';
-import englishCountriesTranslation from 'i18n-iso-countries/langs/en.json';
 import countryCodes from 'country-codes-list';
 
 export type PhoneCodeType = {
@@ -11,18 +8,16 @@ export type PhoneCodeType = {
 export type CountryInfoType = {
   code: string,
   country: string,
-  countryCode: Alpha2Code,
+  countryCode: string,
 }
-
-i18nCountries.registerLocale(englishCountriesTranslation);
 
 const phoneCodes = countryCodes.customArray({
   code: '{countryCallingCode}',
-  countryCode: '{countryCode}' as Alpha2Code,
-}) as { code: string, countryCode: Alpha2Code }[];
+  countryCode: '{countryCode}',
+}) as { code: string, countryCode: string }[];
 
-function getCountriesInfo(countryList: Alpha2Code[], language = 'us') {
-  if (!i18nCountries.langs().includes(language)) throw new Error('No locales provided');
+function getCountriesInfo(countryList: string[], language = 'en') {
+  const countryTranslations = new Intl.DisplayNames([language, 'en'], { type: 'region' });
 
   const filteredPhoneCodes = countryList.length
     ? phoneCodes.filter((item) => (countryList.includes(item.countryCode)))
@@ -32,7 +27,7 @@ function getCountriesInfo(countryList: Alpha2Code[], language = 'us') {
     .map((item) => ({
       ...item,
       code: `+${item.code.replace(/\s+/g, '').replace('-', '')}`,
-      country: i18nCountries.getName(item.countryCode, language),
+      country: countryTranslations.of(item.countryCode),
       countryCode: item.countryCode,
     }))
     .filter((countryInfo): countryInfo is CountryInfoType => !!countryInfo.country)

--- a/src/components/molecules/UiPhoneNumber/helpers/index.ts
+++ b/src/components/molecules/UiPhoneNumber/helpers/index.ts
@@ -34,6 +34,5 @@ function getCountriesInfo(countryList: string[], language = 'en') {
     .sort((a, b) => (a.country.localeCompare(b.country)));
 }
 export {
-  i18nCountries,
   getCountriesInfo,
 };


### PR DESCRIPTION
## Description
Following on finding from https://gitlab.com/Infermedica/development/triage/symptom-checker-app/-/merge_requests/1721, I decided to replace `i18n-iso-countries` - both to reduce dependency size, but also to make the usage simpler, now it will work with all the languages without requiring the manual import of translations.

## Motivation and Context
- reduce dependencies
- improve user experience

## How Has This Been Tested?
Tested in PhoneNumber stories

## Screenshots (if appropriate):

## Checklist:

- [✅] My code follows the style guidelines of this project
- [✅] I have performed a self-review of my code
- [✅] I have made corresponding changes to the documentation
- [✅] My changes generate no new warnings
- [❌] I have added tests that prove my fix is effective or that my feature works
- [✅] New and existing unit tests pass locally with my changes
