### PR TITLE
fix: add missing attrs to fix a11y wave errors

### DIFF
--- a/src/components/organisms/UiModal/UiModal.stories.js
+++ b/src/components/organisms/UiModal/UiModal.stories.js
@@ -46,7 +46,10 @@ export default {
     backdropAttrs: { 'data-testid': 'backdrop' },
     transitionDialogAttrs: { 'data-testid': 'dialog-transition' },
     dialogAttrs: { 'data-testid': 'dialog-element' },
-    headingTitleAttrs: { 'data-testid': 'title-heading' },
+    headingTitleAttrs: {
+      'data-testid': 'title-heading',
+      id: 'title-heading',
+    },
     textContentAttrs: { 'data-testid': 'content-text' },
     buttonConfirmAttrs: { 'data-testid': 'confirm-button' },
     buttonCancelAttrs: { 'data-testid': 'cancel-button' },
@@ -815,6 +818,7 @@ export const WithInputInContentSlot = {
       const button = ref(null);
       const input = ref(null);
       const errorMessage = ref(false);
+      const inputAttrs = { 'aria-labelledby': 'title-heading' };
 
       function onConfirm() {
         if (searchText.value) {
@@ -861,6 +865,7 @@ export const WithInputInContentSlot = {
         onCancel,
         input,
         button,
+        inputAttrs,
       };
     },
     template: `<UiModal
@@ -900,6 +905,7 @@ export const WithInputInContentSlot = {
               'ui-form-field__input',
               { 'ui-input--has-error': errorMessage },
             ]"
+            :input-attrs="inputAttrs"
           />
         </UiFormField>
       </template>
@@ -935,6 +941,7 @@ export const WithWithTextareaAsContentSlotOnMobile = {
       const button = ref(null);
       const textarera = ref(null);
       const errorMessage = ref(false);
+      const textareaAttrs = { 'aria-labelledby': 'title-heading' };
 
       function onConfirm() {
         if (searchText.value) {
@@ -981,6 +988,7 @@ export const WithWithTextareaAsContentSlotOnMobile = {
         onCancel,
         textarera,
         button,
+        textareaAttrs,
       };
     },
     template: `<UiModal
@@ -1021,6 +1029,7 @@ export const WithWithTextareaAsContentSlotOnMobile = {
                   'ui-form-field__textarea',
                   { 'ui-textarea--has-error': errorMessage },
                 ]"
+                :textarea-attrs="textareaAttrs"
               />
             </UiFormField>
         </template>


### PR DESCRIPTION
## Description
Add missing input and textarea attrs

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Closes #512 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
