### PR TITLE
fix: change how country-codes-list is imported

### DIFF
--- a/src/components/molecules/UiPhoneNumber/helpers/index.ts
+++ b/src/components/molecules/UiPhoneNumber/helpers/index.ts
@@ -1,4 +1,4 @@
-import countryCodes from 'country-codes-list';
+import { customArray as getCustomCountryList } from 'country-codes-list';
 
 export type PhoneCodeType = {
   code?: string,
@@ -11,7 +11,7 @@ export type CountryInfoType = {
   countryCode: string,
 }
 
-const phoneCodes = countryCodes.customArray({
+const phoneCodes = getCustomCountryList({
   code: '{countryCallingCode}',
   countryCode: '{countryCode}',
 }) as { code: string, countryCode: string }[];


### PR DESCRIPTION
## Description
This _should_ fix an issue with using UiPhoneNumber.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Closes #

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:

- [✅] My code follows the style guidelines of this project
- [✅] I have performed a self-review of my code
- [N/A] I have made corresponding changes to the documentation
- [✅] My changes generate no new warnings
- [N/A] I have added tests that prove my fix is effective or that my feature works
- [✅] New and existing unit tests pass locally with my changes
