### PR TITLE
v1.9.6

### DIFF
--- a/docs/releases/v1.9.x/v1.9.5/changelog.stories.mdx.mdx
+++ b/docs/releases/v1.9.x/v1.9.5/changelog.stories.mdx.mdx
@@ -1,8 +1,8 @@
 import { Meta } from '@storybook/blocks';
 
-<Meta title="Releases/Removed versions/v1.9.x/v1.9.4/Changelog"/>
+<Meta title="Releases/v1.9.x/v1.9.5/Changelog"/>
   
-# 1.9.4 (August 5, 2024)
+# 1.9.5 (August 5, 2024)
 
 ## 🚀 Feature
 * thumbs icons  ([#519](https://github.com/infermedica/component-library/pull/519))

--- a/docs/releases/v1.9.x/v1.9.6/changelog.stories.mdx.mdx
+++ b/docs/releases/v1.9.x/v1.9.6/changelog.stories.mdx.mdx
@@ -1,0 +1,9 @@
+import { Meta } from '@storybook/blocks';
+
+<Meta title="Releases/v1.9.x/v1.9.6/Changelog"/>
+  
+# 1.9.6 (August 28, 2024)
+
+## 🐛 Fixes
+* change how country-codes-list is imported  ([#524](https://github.com/infermedica/component-library/pull/524))
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infermedica/component-library",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "description": "Vue 3 UI library for healthcare and not only.",
   "license": "MIT",
   "sideEffects": [

--- a/src/components/molecules/UiPhoneNumber/helpers/index.ts
+++ b/src/components/molecules/UiPhoneNumber/helpers/index.ts
@@ -1,4 +1,4 @@
-import countryCodes from 'country-codes-list';
+import { customArray as getCustomCountryList } from 'country-codes-list';
 
 export type PhoneCodeType = {
   code?: string,
@@ -11,7 +11,7 @@ export type CountryInfoType = {
   countryCode: string,
 }
 
-const phoneCodes = countryCodes.customArray({
+const phoneCodes = getCustomCountryList({
   code: '{countryCallingCode}',
   countryCode: '{countryCode}',
 }) as { code: string, countryCode: string }[];


### PR DESCRIPTION
# 1.9.6 (August 28, 2024)

## 🐛 Fixes
* change how country-codes-list is imported  ([#524](https://github.com/infermedica/component-library/pull/524))