### PR TITLE
feat: in UiQuestion add an optional icon for the Why button

### DIFF
--- a/src/components/templates/UiQuestion/UiQuestion.stories.js
+++ b/src/components/templates/UiQuestion/UiQuestion.stories.js
@@ -52,6 +52,7 @@ export default {
       'data-test': 'why-button',
       onClick: events.onClickWhyButton,
     },
+    iconWhyAttrs: { 'data-test': 'info-icon' },
     buttonIssueAttrs: {
       'data-test': 'issue-button',
       onClick: events.onClickIssueButton,
@@ -557,4 +558,73 @@ export const WithIssueSlot = {
       </template>
     </UiQuestion>`,
   }),
+};
+
+export const AsSimpleQuestionWithCustomWhyButton = {
+  render: (args) => ({
+    components: {
+      UiQuestion,
+      UiSimpleQuestion,
+    },
+    setup() {
+      const modelValue = ref('');
+      return {
+        ...args,
+        modelValue,
+      };
+    },
+    template: `<UiQuestion
+      :title="title"
+      :translation="translation"
+      :settings="settings"
+      :heading-title-attrs="headingTitleAttrs"
+      :button-info-attrs="buttonInfoAttrs"
+      :icon-info-attrs="iconInfoAttrs"
+      :button-why-attrs="buttonWhyAttrs"
+      :icon-why-attrs="iconWhyAttrs"
+      :button-issue-attrs="buttonIssueAttrs"
+      :notification-feedback-attrs="notificationFeedbackAttrs"
+    >
+      <UiSimpleQuestion
+        v-model="modelValue"
+        :items="items"
+        :legend="title"
+      />
+    </UiQuestion>`,
+  }),
+
+  args: {
+    title: 'What is your sex?',
+    translation: { why: 'What should I select?' },
+    iconWhyAttrs: {
+      'data-test': 'info-icon',
+      icon: 'info',
+    },
+    items: [
+      {
+        value: 'female',
+        label: 'Female',
+        icon: 'female',
+      },
+      {
+        value: 'male',
+        label: 'Male',
+        icon: 'male',
+      },
+    ],
+  },
+
+  decorators: [ (story) => ({
+    components: {
+      story,
+      UiControls,
+    },
+    template: `<UiControls
+      :to-next="{path: '/next'}"
+      :to-back="{path: '/back'}"
+      class="max-w-195 min-h-135 w-full"
+    >
+      <story/>
+    </UiControls>`,
+  }) ],
 };

--- a/src/components/templates/UiQuestion/UiQuestion.vue
+++ b/src/components/templates/UiQuestion/UiQuestion.vue
@@ -111,7 +111,7 @@
               class="ui-button--small ui-button--text"
             >
               <UiIcon
-                v-if="iconWhyAttrs.icon"
+                v-if="defaultProps.iconWhyAttrs.icon"
                 v-bind="defaultProps.iconWhyAttrs"
                 class="ui-button__icon"
               />

--- a/src/components/templates/UiQuestion/UiQuestion.vue
+++ b/src/components/templates/UiQuestion/UiQuestion.vue
@@ -85,6 +85,7 @@
         buttonIssueAttrs,
         settings: defaultProps.settings,
         translation: defaultProps.translation,
+        iconWhyAttrs: defaultProps.iconWhyAttrs,
       }"
     >
       <div
@@ -98,6 +99,7 @@
             settings: defaultProps.settings,
             translation: defaultProps.translation,
             buttonWhyAttrs,
+            iconWhyAttrs: defaultProps.iconWhyAttrs,
           }"
         >
           <div
@@ -108,6 +110,11 @@
               v-bind="buttonWhyAttrs"
               class="ui-button--small ui-button--text"
             >
+              <UiIcon
+                v-if="iconWhyAttrs.icon"
+                v-bind="defaultProps.iconWhyAttrs"
+                class="ui-button__icon"
+              />
               {{ defaultProps.translation.why }}
             </UiButton>
           </div>
@@ -222,6 +229,10 @@ export interface QuestionProps {
    */
   buttonWhyAttrs?: ButtonAttrsProps;
   /**
+   * Use this props to pass attrs for why UiIcon
+   */
+  iconWhyAttrs?: IconAttrsProps;
+  /**
    * Use this props to pass attrs for issue UiButton
    */
   buttonIssueAttrs?: ButtonAttrsProps;
@@ -257,6 +268,7 @@ const props = withDefaults(defineProps<QuestionProps>(), {
   buttonInfoAttrs: () => ({}),
   iconInfoAttrs: () => ({ icon: 'info' }),
   buttonWhyAttrs: () => ({}),
+  iconWhyAttrs: () => ({ }),
   buttonIssueAttrs: () => ({}),
   notificationFeedbackAttrs: () => ({ type: 'success' }),
 });
@@ -295,6 +307,7 @@ const defaultProps = computed(() => {
       icon,
       ...props.iconInfoAttrs,
     },
+    iconWhyAttrs: { ...props.iconWhyAttrs },
     notificationFeedbackAttrs: {
       type,
       ...props.notificationFeedbackAttrs,


### PR DESCRIPTION
## Description
It adds an optional `icon` to the why button in `UiQuestion`. I need this icon because question about sex has this icon:
![image](https://github.com/user-attachments/assets/267ac031-14f8-4987-b33a-46a0a921358f)


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Closes #

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
