### PR TITLE
feat: remove personal paths from generated docs

### DIFF
--- a/scripts/update-components-api.mjs
+++ b/scripts/update-components-api.mjs
@@ -23,7 +23,12 @@ const getComponentsApi = async () => {
   pathsComponentsLoop((componentPath) => {
     promises.push(vueDocs.parse(`${pathComponentsRoot}/${componentPath}`));
   });
-  const componentsApi = await Promise.all(promises);
+  const componentsApi = (await Promise.all(promises))
+    .map((component) => ({
+      ...component,
+      sourceFiles: component.sourceFiles.map((sourceFile) => sourceFile
+        .replace(pathComponentsRoot, '/src/components')),
+    }));
   return componentsApi;
 };
 function saveComponentsApiFile(componentsApi) {


### PR DESCRIPTION
## Description
Removes `/Users/$USER_NAME/$PATH_TO_FILE` from `sourceFiles` attribute of generated vueDocs.

## Motivation and Context
Without this, every release from a different person than previous release would have changes like [this](https://github.com/infermedica/component-library/compare/develop...releases/v1.11.0#diff-e4bea14483c3a87f568f92973fb4a5d727252c4628b7ed69ca2f8beede906afe) depending on personal path where `Component Library` is stored.

I haven't found any other way in documentation to achieve this, `vueDocs.parse(path)` seems to push to `sourceFiles` just the `path` without any modification, while requiring `absolutePath`, so the only other way for "fix" I see here is running this script in CI instead of locally, but that's significantly bigger scope.

## How Has This Been Tested?
Running `pnpm release`

## Screenshots (if appropriate):
![Screenshot 2025-01-10 at 09 23 27](https://github.com/user-attachments/assets/46c850fa-0f68-4910-9cea-1f522fdf2b88)


## Checklist:

- [✅] My code follows the style guidelines of this project
- [✅] I have performed a self-review of my code
- [❌] I have made corresponding changes to the documentation
- [✅] My changes generate no new warnings
- [✅] I have added tests that prove my fix is effective or that my feature works
- [✅] New and existing unit tests pass locally with my changes
