### PR TITLE
fix: scroll to the first invalid radio for Safari on IOS (MGPFE-312)

### DIFF
--- a/src/components/organisms/UiMultipleChoices/UiMultipleChoices.vue
+++ b/src/components/organisms/UiMultipleChoices/UiMultipleChoices.vue
@@ -70,7 +70,10 @@ import type { RadioAttrsProps } from '../../atoms/UiRadio/UiRadio.vue';
 import UiMultipleChoicesItem from './_internal/UiMultipleChoicesItem.vue';
 import type { MultipleChoicesItemAttrsProps } from './_internal/UiMultipleChoicesItem.vue';
 import type { DefineAttrsProps } from '../../../types/attrs';
-import { focusElement } from '../../../utilities/helpers';
+import {
+  focusElement,
+  isSafariOnIOS,
+} from '../../../utilities/helpers';
 
 export type MultipleChoicesOption = RadioAttrsProps & { label?: string };
 export type MultipleChoicesModelValue = string | Record<string, unknown>;
@@ -145,6 +148,16 @@ const updateHandler = (newValue: MultipleChoicesModelValue, index: number) => {
   emit('update:modelValue', value.value);
 };
 
+// NOTE: hack only for Safari on IOS
+function scrollToFirstInvalidInput(el: HTMLElement) {
+  el.setAttribute('tabindex', '0');
+  el.scrollIntoView({
+    behavior: 'smooth',
+    block: 'center',
+  });
+  el.removeAttribute('tabindex');
+}
+
 function focusInvalidChoice() {
   const firstInvalidChoice = multipleChoicesItemRefs.value.find((element, index) => hasError(index));
   if (!firstInvalidChoice) return;
@@ -153,8 +166,12 @@ function focusInvalidChoice() {
   const firstRadioItemsInput = choicesFirstRadioItem?.content?.input;
 
   const elementToFocus = firstRadioItemsInput ?? firstInvalidChoice.$el.querySelector('input');
+  const elementToScroll = firstRadioItemsInput ?? firstInvalidChoice.$el;
 
   focusElement(elementToFocus, true);
+
+  if (isSafariOnIOS()) scrollToFirstInvalidInput(elementToScroll);
+
   emit('focus:invalidChoice', elementToFocus);
 }
 

--- a/src/utilities/helpers/index.ts
+++ b/src/utilities/helpers/index.ts
@@ -3,3 +3,4 @@ export * from './remove-non-digits/index';
 export * from './focus-element/index';
 export * from './equal/index';
 export * from './focus-on-first-invalid-choice/index';
+export * from './isSafariOnIOS/index';

--- a/src/utilities/helpers/isSafariOnIOS/index.ts
+++ b/src/utilities/helpers/isSafariOnIOS/index.ts
@@ -1,0 +1,6 @@
+// eslint-disable-next-line import/prefer-default-export
+export function isSafariOnIOS(): boolean {
+  const { userAgent } = navigator;
+
+  return /iP(hone|ad|od)/.test(userAgent) && /Safari/.test(userAgent) && !/Chrome/.test(userAgent);
+}


### PR DESCRIPTION
## Description
Add checking if browser is Safari on IOS function
Add `scrollIntoView` for Safari on IOS

## Related Issue
MGPFE-312
Closes #

## Motivation and Context
To solve problem with auto scroll to the first invalid radio

## How Has This Been Tested?
In project MGP

## Screenshots (if appropriate):
Safari on IOS

https://github.com/user-attachments/assets/33e9c3fc-da3c-455f-a00d-0fd8f81af5b1

Safari:

https://github.com/user-attachments/assets/265b7692-65eb-4269-9350-f0b344ce3138

Chrome:

https://github.com/user-attachments/assets/64de3d51-dfe6-4458-80f0-0e52fd8a642a



## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
