### PR TITLE
fix: change text align for menu content

### DIFF
--- a/src/components/atoms/UiButton/UiButton.vue
+++ b/src/components/atoms/UiButton/UiButton.vue
@@ -133,7 +133,7 @@ const loader = computed(() => (
   background: functions.var($element, background, var(--color-background-action));
   color: functions.var($element, color, var(--color-text-on-action));
   gap: functions.var($element, gap, var(--space-4));
-  text-align: center;
+  text-align: functions.var($element, text-align, center);
   text-decoration: none;
   transition:
     (

--- a/src/components/organisms/UiMenu/_internal/UiMenuItem.vue
+++ b/src/components/organisms/UiMenu/_internal/UiMenuItem.vue
@@ -101,6 +101,8 @@ defineExpose({
   justify-content: flex-start;
 
   &__content {
+    --button-text-align: start;
+
     @include mixins.override-logical(button, $element + "-content", border-radius, var(--border-radius-form));
     @include mixins.override-logical(button, $element + "-content", padding, var(--space-8));
     @include mixins.override-logical(button, null, border-width, 0);


### PR DESCRIPTION
## Description
Added text-align var for button and overwrite it for ui-menu-item with `start`. This should prevent longer text from displaying as centered.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Closes #

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
