### PR TITLE
fix uirating using only default setting prop value

### DIFF
--- a/src/components/molecules/UiRating/UiRating.vue
+++ b/src/components/molecules/UiRating/UiRating.vue
@@ -235,11 +235,11 @@ const itemsToRender = computed<RatingRenderItem[]>(() => (Array.from({ length: m
     ...radioOptionAttrs,
     index: index + 1,
     iconActiveAttrs: {
-      icon: defaultProps.value.settings.iconActive,
+      icon: props.settings.iconActive,
       ...radioOptionAttrs?.iconActiveAttrs,
     },
     iconDefaultAttrs: {
-      icon: defaultProps.value.settings.iconDefault,
+      icon: props.settings.iconDefault,
       ...radioOptionAttrs?.iconDefaultAttrs,
     },
     textLabelAttrs: {


### PR DESCRIPTION
## Description
UiRating wont use the provided settings prop

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Closes #

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
