### PR TITLE
fix: correct month names localization in Datepicker

### DIFF
--- a/src/components/organisms/UiDatepicker/UiDatepicker.vue
+++ b/src/components/organisms/UiDatepicker/UiDatepicker.vue
@@ -288,7 +288,21 @@ const datePartElements: Record<DatepickerDatePart, DatepickerInput | null> = {
 const setDatePartElement = (el: DatepickerInput, datePart: DatepickerDatePart): void => {
   datePartElements[datePart] = el;
 };
-const monthNames = ref<string[]>([]);
+
+const monthList = (locale: string): string[] => {
+  const getMonth = new Intl.DateTimeFormat(locale, { month: 'long' }).format;
+  return [ ...Array(12).keys() ].map((m) => getMonth(new Date(2022, m)));
+};
+
+const monthNames = computed(() => {
+  try {
+    return monthList(props.lang);
+  } catch {
+    console.error('Unrecognized language props value, default \'en-us\' language loaded'); // eslint-disable-line no-console
+    return monthList('en-US');
+  }
+});
+
 provide<Ref<string[]>>('monthNames', monthNames);
 const date = reactive<DatepickerDate<string>>({
   day: '',
@@ -527,22 +541,7 @@ watch(isDayFulfilled, (fulfilled: boolean) => handleFulfilledChange(fulfilled, '
 watch(isMonthFulfilled, (fulfilled: boolean) => handleFulfilledChange(fulfilled, 'month', date.month, isMonthValid.value));
 watch(isYearFulfilled, (fulfilled: boolean) => handleFulfilledChange(fulfilled, 'year', date.year, isYearValid.value));
 
-const monthList = (locale: string): string[] => {
-  const getMonth = new Intl.DateTimeFormat(locale, { month: 'long' }).format;
-  return [ ...Array(12).keys() ].map((m) => getMonth(new Date(2022, m)));
-};
-
-const localizeMonths = () => {
-  try {
-    monthNames.value = monthList(props.lang);
-  } catch {
-    monthNames.value = monthList('en-US');
-    console.error('Unrecognized language props value, default \'en-us\' language loaded'); // eslint-disable-line no-console
-  }
-};
-
 onMounted(() => {
-  localizeMonths();
   if (props.modelValue) {
     assignDateParts();
   }


### PR DESCRIPTION
## Description
I've fixed a part of the published issue: ["Data picker behaviour with non-English"](https://github.com/infermedica/component-library/issues/526). 

When you change the language, the months in the date picker didn’t update and showed incorrect translations.

Commits:
[fix: correct month names localization in Datepicker and replace monthNames ref with computed](https://github.com/infermedica/component-library/pull/547/commits/f8b7d24b2111d42a712909bac548180b7545e58c)
→ I've made monthNames a computed property that updates automatically when props.lang changes

The issue with the capitalization of the first letter in month names is not fixed in this PR.
I plan to address it in a separate fix after this PR is successfully merged.

## Related Issue
["Issue 526: Data picker behaviour with non-English"](https://github.com/infermedica/component-library/issues/526). 

steps to reproduce:
Go to https://component.infermedica.com/?path=/story/organisms-datepicker--full-configuration
Click on props.lang
Select any language other than en or en-us
See that nothing changes in Month tab

Closes #

## Motivation and Context
["Issue 526: Data picker behaviour with non-English"](https://github.com/infermedica/component-library/issues/526). 
When changing the language, the months in the date picker didn’t update and showed incorrect translations.


## How Has This Been Tested?
You can test it by using the DatePicker component and changing the lang prop.
Example:

```
<UiDatepicker :lang="selectedLang" />
```

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/66127182-a234-4dcb-bf8b-f437d3dfdd09


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
